### PR TITLE
export CalloutManager for testing statically linked libraries

### DIFF
--- a/src/lib/hooks/Makefile.am
+++ b/src/lib/hooks/Makefile.am
@@ -60,7 +60,8 @@ libkea_hooks_include_HEADERS = \
     callout_handle.h \
     callout_manager.h \
     library_handle.h \
-    hooks.h
+    hooks.h \
+    server_hooks.h
 
 if USE_CLANGPP
 # Disable unused parameter warning caused by some of the


### PR DESCRIPTION
We at Facebook need to be able to create new CalloutHandle objects for testing purposes.
