### PR TITLE
Add "query4" argument to hook point pkt4_send

### DIFF
--- a/src/bin/dhcp4/dhcp4_hooks.dox
+++ b/src/bin/dhcp4/dhcp4_hooks.dox
@@ -187,6 +187,9 @@ packet processing. Hook points that are not specific to packet processing
    (This is scratch space used for constructing the packet after all
    pkt4_send callouts are complete, so any changes to that field will
    be overwritten.)\n\n
+   The argument query4 contains a pointer to the corresponding query packet
+   (allowing to perform correlation between response and query). This object
+   cannot be modified.
 
  - <b>Skip flag action</b>: if any callout sets the skip flag, the server
    will not construct raw buffer. The expectation is that if the callout

--- a/src/bin/dhcp4/dhcp4_hooks.dox
+++ b/src/bin/dhcp4/dhcp4_hooks.dox
@@ -176,16 +176,17 @@ packet processing. Hook points that are not specific to packet processing
 
  - @b Arguments:
    - name: @b response4, type: isc::dhcp::Pkt4Ptr, direction: <b>in/out</b>
+   - name: @b query4, type: isc::dhcp::Pkt4Ptr, direction: <b>in</b>
 
  - @b Description: this callout is executed when server's response
-   is about to be sent back to the client. The sole argument - response4 -
+   is about to be sent back to the client. The argument response4
    contains a pointer to an isc::dhcp::Pkt4 object that contains the
    packet, with source and destination addresses set, interface over which
    it will be sent, and a list of all options and relay information.  All fields
    of the Pkt4 object can be modified at this time, except buffer_out_.
    (This is scratch space used for constructing the packet after all
    pkt4_send callouts are complete, so any changes to that field will
-   be overwritten.)
+   be overwritten.)\n\n
 
  - <b>Skip flag action</b>: if any callout sets the skip flag, the server
    will not construct raw buffer. The expectation is that if the callout

--- a/src/bin/dhcp4/dhcp4_srv.cc
+++ b/src/bin/dhcp4/dhcp4_srv.cc
@@ -527,6 +527,9 @@ Dhcpv4Srv::run() {
             // Set our response
             callout_handle->setArgument("response4", rsp);
 
+            // Also pass the corresponding query packet as argument
+            callout_handle->setArgument("query4", query);
+
             // Call all installed callouts
             HooksManager::callCallouts(hook_index_pkt4_send_,
                                        *callout_handle);


### PR DESCRIPTION
This allows the user hook library to perform correlation between the response packet about to be sent back and the corresponding query packet.

(note: to be consistent, the same change should be applied to pkt6_send. I did not do it because I cannot test it.)