### PR TITLE
Trac 3963 -- Dhcpv4Srv::processDiscover() shouldn't return a null PtkPtr is a hook lib is registered

### DIFF
--- a/src/bin/dhcp4/dhcp4_srv.cc
+++ b/src/bin/dhcp4/dhcp4_srv.cc
@@ -1190,8 +1190,7 @@ Dhcpv4Srv::assignLease(Dhcpv4Exchange& ex) {
         // information about the subnet he is connected to. This likely means
         // misconfiguration of the server (or some relays).
 
-        // Perhaps this should be logged on some higher level? This is most
-        // likely configuration bug.
+        // Perhaps this should be logged on some higher level?
         if (HooksManager::calloutsPresent(hook_index_pkt4_send_)) {
           // if a callout for pkt4_send is registered we assume the author of
           // the hook library knows what he's doing and will populate the

--- a/src/bin/dhcp4/dhcp4_srv.cc
+++ b/src/bin/dhcp4/dhcp4_srv.cc
@@ -1195,17 +1195,17 @@ Dhcpv4Srv::assignLease(Dhcpv4Exchange& ex) {
           // if a callout for pkt4_send is registered we assume the author of
           // the hook library knows what he's doing and will populate the
           // egressing packet properly, so we demote this log line to DEBUG
-          LOG_DEBUG(bad_packet_logger, DBG_DHCP4_BASIC, DHCP4_PACKET_NAK_0001)
+          LOG_DEBUG(bad_packet4_logger, DBG_DHCP4_BASIC, DHCP4_PACKET_NAK_0001)
               .arg(query->getLabel())
               .arg(query->getRemoteAddr().toText())
-              .arg(serverReceivedPacketName(query->getType()));
+              .arg(query->getName());
         } else {
           // if there is no hook library registered then this is likely to be
           // a real configuration issue
-          LOG_ERROR(bad_packet_logger, DHCP4_PACKET_NAK_0001)
+          LOG_ERROR(bad_packet4_logger, DHCP4_PACKET_NAK_0001)
               .arg(query->getLabel())
               .arg(query->getRemoteAddr().toText())
-              .arg(serverReceivedPacketName(query->getType()));
+              .arg(query->getName());
         }
         resp->setType(DHCPNAK);
         resp->setYiaddr(IOAddress::IPV4_ZERO_ADDRESS());

--- a/src/bin/dhcp4/tests/dhcp4_test_utils.cc
+++ b/src/bin/dhcp4/tests/dhcp4_test_utils.cc
@@ -559,7 +559,8 @@ Dhcpv4SrvTest::testDiscoverRequest(const uint8_t msg_type) {
 
     if (msg_type == DHCPDISCOVER) {
         ASSERT_NO_THROW(rsp = srv->processDiscover(received));
-        // Should return NULL packet.
+        // Should return NULL packet if no hook callout is registered
+        // (which is the case in this test).
         ASSERT_FALSE(rsp);
 
     } else {


### PR DESCRIPTION
Hi,
I've already opened a ticket @ http://kea.isc.org/ticket/3963
Copy pasting from the ticket:

> Hi, my name is Angelo, and I'm a Production Engineer at Facebook.
> As you know we use KEA in our Facebook DCs, see ​http://isc.org/blogs/how-facebook-is-using-kea-in-the-datacenter/
> We wrote a custom hook library.
> 
> We recently started trying 0.9.2 after it was released, and we noticed that the way Dhcpv4Srv::processDiscover() works in 0.9.2 is causing a regression in our hook library.
Basically Dhcpv4Srv::processDiscover() returns a NULL pointer if a lease can't be assigned. However this is a perfectly valid thing that can happen in our environment. We don't care about leases as we use our hook library to modify egressing packets populating the options we want based of our inventory system database.

> I've written a patch, please let me know which way you prefer for review it, my preferred way is a pull request on github.
Basically the way it works is that the code checks if a hook library is registered, if it is not everything works as before, otherwise an empty Pkt4 is returned (like it was in the past with bind10 or kea <0.9.2).
