### PR TITLE
kea-admin: support for database host parameter

### DIFF
--- a/src/bin/admin/admin-utils.sh
+++ b/src/bin/admin/admin-utils.sh
@@ -22,7 +22,7 @@ mysql_execute() {
         mysql -N -B  $* -e "${QUERY}"
         retcode=$?
     else
-        mysql -N -B --user=$db_user --password=$db_password -e "${QUERY}" $db_name
+        mysql -N -B --host=$db_host --user=$db_user --password=$db_password -e "${QUERY}" $db_name
         retcode="$?"
     fi
 
@@ -52,7 +52,7 @@ pgsql_execute() {
         retcode=$?
     else
         export PGPASSWORD=$db_password
-        echo $QUERY | psql --set ON_ERROR_STOP=1 -A -t -h localhost -q -U $db_user -d $db_name
+        echo $QUERY | psql --set ON_ERROR_STOP=1 -A -t -h $db_host -q -U $db_user -d $db_name
         retcode=$?
     fi
     return $retcode
@@ -76,7 +76,7 @@ pgsql_execute_script() {
         retcode=$?
     else
         export PGPASSWORD=$db_password
-        psql --set ON_ERROR_STOP=1 -A -t -h localhost -q -U $db_user -d $db_name -f $file
+        psql --set ON_ERROR_STOP=1 -A -t -h $db_host -q -U $db_user -d $db_name -f $file
         retcode=$?
     fi
     return $retcode

--- a/src/bin/admin/kea-admin.in
+++ b/src/bin/admin/kea-admin.in
@@ -21,6 +21,7 @@ scripts_dir=${SCRIPTS_DIR_DEFAULT}
 
 # These are the default parameters. They will likely not work in any
 # specific deployment.
+db_host="localhost"
 db_user="keatest"
 db_password="keatest"
 db_name="keatest"
@@ -59,6 +60,7 @@ usage() {
     printf "\n"
     printf "PARAMETERS: Parameters are optional in general, but may be required\n"
     printf "            for specific operation.\n"
+    printf " -h or --host hostname - specifies a hostname of a database to connect to\n"
     printf " -u or --user name - specifies username when connecting to a database\n"
     printf " -p or --password pass - specifies a password when connecting to a database\n"
     printf " -n or --name database - specifies a database name to connect to\n"
@@ -153,7 +155,7 @@ mysql_init() {
     fi
 
     printf "Initializing database using script %s\n" $scripts_dir/mysql/dhcpdb_create.mysql
-    mysql -B --user=$db_user --password=$db_password $db_name < $scripts_dir/mysql/dhcpdb_create.mysql
+    mysql -B --host=$db_host --user=$db_user --password=$db_password $db_name < $scripts_dir/mysql/dhcpdb_create.mysql
     ERRCODE=$?
 
     printf "mysql returned status code $ERRCODE\n"
@@ -260,7 +262,7 @@ mysql_upgrade() {
     for script in ${scripts_dir}/mysql/upgrade*.sh
     do
         echo "Processing $script file..."
-        sh ${script} --user=${db_user} --password=${db_password} ${db_name}
+        sh ${script} --host=${db_host} --user=${db_user} --password=${db_password} ${db_name}
     done
 
     printf "Lease DB version reported after upgrade: "
@@ -292,7 +294,7 @@ pgsql_upgrade() {
     for script in ${scripts_dir}/pgsql/upgrade*.sh
     do
         echo "Processing $script file..."
-        sh ${script} -U ${db_user} -h localhost -d ${db_name}
+        sh ${script} -U ${db_user} -h ${db_host} -d ${db_name}
     done
 
     version=`pgsql_version`
@@ -457,7 +459,7 @@ pgsql_dump() {
 
     # Call psql and redirect output to the dump file. We don't use psql "to csv"
     # as it can only be run as db superuser.
-    echo "$dump_qry" | psql --set ON_ERROR_STOP=1 -t -h localhost -q --user=$db_user --dbname=$db_name -w --no-align --field-separator=',' >$dump_file
+    echo "$dump_qry" | psql --set ON_ERROR_STOP=1 -t -h $db_host -q --user=$db_user --dbname=$db_name -w --no-align --field-separator=',' >$dump_file
     retcode=$?
 
     # Check for errors.
@@ -547,6 +549,16 @@ while [ ! -z "${1}" ]
 do
     option=${1}
     case ${option} in
+        # Specify database host
+        -h|--host)
+            shift
+            db_host=${1}
+            if [ -z ${db_host} ]; then
+                log_error "-h or --host requires a parameter"
+                usage
+                exit 1
+            fi
+            ;;
         # Specify database user
         -u|--user)
             shift


### PR DESCRIPTION
We came along trying kea with a mysql backend hosted on another machine, however the kea-admin script does not support non-localhost databases.

This patch adds an additional parameter to the script(s): `-h` or long `--host`.

I verified its working for mysql but the psql is highly likely to work just as well given the simplicity of these changes.

BTW my changes are in one single commit (064e6511d510e7dd662ada392ea1bc7186557782), however your github clone's master branch is some weeks behind git.kea.isc.org so this MR seems somewhat messy.
