### PR TITLE
dhcpdb_create.mysql: Explicitly create all MySQL tables using the InnoDB engine

### DIFF
--- a/src/bin/admin/scripts/mysql/dhcpdb_create.mysql
+++ b/src/bin/admin/scripts/mysql/dhcpdb_create.mysql
@@ -92,7 +92,7 @@ CREATE INDEX lease6_by_iaid_subnet_id_duid ON lease6 (iaid, subnet_id, duid);
 CREATE TABLE lease6_types (
     lease_type TINYINT PRIMARY KEY NOT NULL,    # Lease type code.
     name VARCHAR(5)                             # Name of the lease type
-    );
+    ) ENGINE = INNODB;
 START TRANSACTION;
 INSERT INTO lease6_types VALUES (0, "IA_NA");   # Non-temporary v6 addresses
 INSERT INTO lease6_types VALUES (1, "IA_TA");   # Temporary v6 addresses
@@ -111,7 +111,7 @@ COMMIT;
 CREATE TABLE schema_version (
     version INT PRIMARY KEY NOT NULL,       # Major version number
     minor INT                               # Minor version number
-    );
+    ) ENGINE = INNODB;
 START TRANSACTION;
 INSERT INTO schema_version VALUES (1, 0);
 COMMIT;
@@ -136,7 +136,7 @@ ALTER TABLE lease6
 CREATE TABLE lease_hwaddr_source (
     hwaddr_source INT PRIMARY KEY NOT NULL,
     name VARCHAR(40)
-);
+) ENGINE = INNODB;
 
 # Hardware address obtained from raw sockets
 INSERT INTO lease_hwaddr_source VALUES (1, "HWADDR_SOURCE_RAW");


### PR DESCRIPTION
Make sure to explicitly create all tables using the InnoDB storage engine to prevent failure of foreign key creation (e.g. between fields in the 'lease6' and 'lease6_types' tables) on the off chance that the database's default storage engine is MyISAM.