### PR TITLE
[perfdhcp] [bugfix] use the same transaction id for the duration of a DORA session.

### DIFF
--- a/src/bin/perfdhcp/test_control.cc
+++ b/src/bin/perfdhcp/test_control.cc
@@ -1871,8 +1871,7 @@ TestControl::sendRequest4(const TestControlSocket& socket,
 void
 TestControl::sendRequest6(const TestControlSocket& socket,
                           const Pkt6Ptr& advertise_pkt6) {
-    // Use the same transaction id for the duration of the session
-    const uint32_t transid = advertise_pkt6->getTransid();
+    const uint32_t transid = generateTransid();
     Pkt6Ptr pkt6(new Pkt6(DHCPV6_REQUEST, transid));
     // Set elapsed time.
     OptionPtr opt_elapsed_time =
@@ -1929,8 +1928,8 @@ TestControl::sendRequest6(const TestControlSocket& socket,
     // Get the second argument if multiple the same arguments specified
     // in the command line. Second one refers to REQUEST packets.
     const uint8_t arg_idx = 1;
-    // Use same transid of the advertise response
-    const uint32_t transid = advertise_pkt6->getTransid();
+    // Generate transaction id.
+    const uint32_t transid = generateTransid();
     // Get transaction id offset.
     size_t transid_offset = getTransactionIdOffset(arg_idx);
     PerfPkt6Ptr pkt6(new PerfPkt6(&template_buf[0], template_buf.size(),

--- a/src/bin/perfdhcp/test_control.cc
+++ b/src/bin/perfdhcp/test_control.cc
@@ -1699,7 +1699,8 @@ void
 TestControl::sendRequest4(const TestControlSocket& socket,
                           const dhcp::Pkt4Ptr& discover_pkt4,
                           const dhcp::Pkt4Ptr& offer_pkt4) {
-    const uint32_t transid = generateTransid();
+    // Use the same transaction id as the one used in the discovery packet.
+    const uint32_t transid = discover_pkt4->getTransid();
     Pkt4Ptr pkt4(new Pkt4(DHCPREQUEST, transid));
 
     // Use first flags indicates that we want to use the server
@@ -1765,8 +1766,8 @@ TestControl::sendRequest4(const TestControlSocket& socket,
     // Get the second argument if multiple the same arguments specified
     // in the command line. Second one refers to REQUEST packets.
     const uint8_t arg_idx = 1;
-    // Generate new transaction id.
-    const uint32_t transid = generateTransid();
+    // Use the same transaction id as the one used in the discovery packet.
+    const uint32_t transid = discover_pkt4->getTransid();
     // Get transaction id offset.
     size_t transid_offset = getTransactionIdOffset(arg_idx);
     // Get the offset of MAC's last octet.

--- a/src/bin/perfdhcp/test_control.cc
+++ b/src/bin/perfdhcp/test_control.cc
@@ -1871,7 +1871,8 @@ TestControl::sendRequest4(const TestControlSocket& socket,
 void
 TestControl::sendRequest6(const TestControlSocket& socket,
                           const Pkt6Ptr& advertise_pkt6) {
-    const uint32_t transid = generateTransid();
+    // Use the same transaction id for the duration of the session
+    const uint32_t transid = advertise_pkt6->getTransid();
     Pkt6Ptr pkt6(new Pkt6(DHCPV6_REQUEST, transid));
     // Set elapsed time.
     OptionPtr opt_elapsed_time =
@@ -1928,8 +1929,8 @@ TestControl::sendRequest6(const TestControlSocket& socket,
     // Get the second argument if multiple the same arguments specified
     // in the command line. Second one refers to REQUEST packets.
     const uint8_t arg_idx = 1;
-    // Generate transaction id.
-    const uint32_t transid = generateTransid();
+    // Use same transid of the advertise response
+    const uint32_t transid = advertise_pkt6->getTransid();
     // Get transaction id offset.
     size_t transid_offset = getTransactionIdOffset(arg_idx);
     PerfPkt6Ptr pkt6(new PerfPkt6(&template_buf[0], template_buf.size(),

--- a/src/bin/perfdhcp/tests/test_control_unittest.cc
+++ b/src/bin/perfdhcp/tests/test_control_unittest.cc
@@ -1402,7 +1402,7 @@ TEST_F(TestControlTest, Packet4Exchange) {
     const int received_num = 10;
     use_templates = true;
     testPkt4Exchange(iterations_num, received_num, use_templates, iterations_performed);
-    EXPECT_EQ(12, iterations_performed);
+    EXPECT_EQ(11, iterations_performed);
 }
 
 TEST_F(TestControlTest, Packet6ExchangeFromTemplate) {


### PR DESCRIPTION
Found this out when making some benchmark testing. The XID is incremented wrongly.
A XID should last for the duration of a SORA 4-way handshake...

```
    $ perfdhcp -4 -r 1 -n 2 -p 60 -t 1 -b mac=90:e2:ba:95:b9:28 10.88.45.33
    $ sudo tshark udp port 67
    Running as user "root" and group "root". This could be dangerous.
    Capturing on 'eth0'
      1   0.000000 10.35.166.47 -> 10.88.45.33  DHCP 295 DHCP Discover - Transaction ID 0x0
      2   0.030098  10.88.45.33 -> 10.35.166.47 DHCP 416 DHCP Offer    - Transaction ID 0x0
      3   0.030426 10.35.166.47 -> 10.88.45.33  DHCP 307 DHCP Request  - Transaction ID 0x1
      4   0.057158  10.88.45.33 -> 10.35.166.47 DHCP 416 DHCP ACK      - Transaction ID 0x1
      5   1.000689 10.35.166.47 -> 10.88.45.33  DHCP 295 DHCP Discover - Transaction ID 0x2
      6   1.027757  10.88.45.33 -> 10.35.166.47 DHCP 416 DHCP Offer    - Transaction ID 0x2
      7   1.027866 10.35.166.47 -> 10.88.45.33  DHCP 307 DHCP Request  - Transaction ID 0x3
      8   1.047429  10.88.45.33 -> 10.35.166.47 DHCP 416 DHCP ACK      - Transaction ID 0x3
```

My PR fixes this:

 ```
 $ perfdhcp -4 -r 1 -n 2 -p 60 -t 1 -b mac=90:e2:ba:95:b9:28 10.88.45.33
 $ sudo tshark udp port 67
 Running as user "root" and group "root". This could be dangerous.
 Capturing on 'eth0'
   1   0.000000 10.35.166.47 -> 10.88.45.33  DHCP 304 DHCP Discover - Transaction ID 0x0
   2   0.031211  10.88.45.33 -> 10.35.166.47 DHCP 425 DHCP Offer    - Transaction ID 0x0
   3   0.031517 10.35.166.47 -> 10.88.45.33  DHCP 316 DHCP Request  - Transaction ID 0x0
   4   0.061698  10.88.45.33 -> 10.35.166.47 DHCP 425 DHCP ACK      - Transaction ID 0x0
   5   1.000589 10.35.166.47 -> 10.88.45.33  DHCP 304 DHCP Discover - Transaction ID 0x1
   6   1.018230  10.88.45.33 -> 10.35.166.47 DHCP 425 DHCP Offer    - Transaction ID 0x1
   7   1.018360 10.35.166.47 -> 10.88.45.33  DHCP 316 DHCP Request  - Transaction ID 0x1
   8   1.058186  10.88.45.33 -> 10.35.166.47 DHCP 425 DHCP ACK      - Transaction ID 0x1
 ```

Need to modify unit tests