### PR TITLE
Fix compilation with GCC 6.0 std::make_pair changes

### DIFF
--- a/src/lib/dhcpsrv/pgsql_lease_mgr.cc
+++ b/src/lib/dhcpsrv/pgsql_lease_mgr.cc
@@ -1275,7 +1275,7 @@ PgSqlLeaseMgr::getVersion() const {
     tmp.str(PQgetvalue(r, 0, 1));
     tmp >> minor;
 
-    return make_pair<uint32_t, uint32_t>(version, minor);
+    return std::pair<uint32_t, uint32_t>(version, minor);
 }
 
 void


### PR DESCRIPTION
With C++14, `std::make_pair<T,U>(t,u)` expects an `rvalue`. If trying
to pass an lvalue, either use `std::make_pair(t,u)` and type is
deduced, or use `std::pair<T,U>(t,y)`.
