### PR TITLE
Fix compilation with GCC 6.0 std::make_pair changes

### DIFF
--- a/src/lib/dhcpsrv/cql_lease_mgr.cc
+++ b/src/lib/dhcpsrv/cql_lease_mgr.cc
@@ -1954,7 +1954,7 @@ CqlLeaseMgr::getVersion() const {
     cass_future_free(future);
     cass_statement_free(statement);
 
-    return make_pair<uint32_t, uint32_t>(version, minor);
+    return make_pair(version, minor);
 }
 
 void

--- a/src/lib/dhcpsrv/pgsql_host_data_source.cc
+++ b/src/lib/dhcpsrv/pgsql_host_data_source.cc
@@ -1698,7 +1698,7 @@ std::pair<uint32_t, uint32_t> PgSqlHostDataSourceImpl::getVersion() const {
     uint32_t minor;
     PgSqlExchange::getColumnValue(r, 0, 0, minor);
 
-    return (std::make_pair<uint32_t, uint32_t>(version, minor));
+    return (std::make_pair(version, minor));
 }
 
 void

--- a/src/lib/dhcpsrv/pgsql_lease_mgr.cc
+++ b/src/lib/dhcpsrv/pgsql_lease_mgr.cc
@@ -1391,7 +1391,7 @@ PgSqlLeaseMgr::getVersion() const {
     tmp.str(PQgetvalue(r, 0, 1));
     tmp >> minor;
 
-    return make_pair<uint32_t, uint32_t>(version, minor);
+    return make_pair(version, minor);
 }
 
 void


### PR DESCRIPTION
With C++14, std::make_pair<T,U>(t,u) expects rvalue. If trying
to pass an lvalue, either std::make_pair(t,u) and type is
deduced, or std::pair<T,U>(t,y).

(commit message by @AdamMajer)

This is the same issue was discussed in #28 but covering more cases.