### PR TITLE
Use correct CONFIG variable in LFC test.

### DIFF
--- a/src/bin/dhcp4/tests/dhcp4_process_tests.sh.in
+++ b/src/bin/dhcp4/tests/dhcp4_process_tests.sh.in
@@ -318,7 +318,7 @@ lfc_timer_test() {
     sleep 1
 
     # Modify the interval.
-    LFC_CONFIG=$(printf "${CONFIG}" | sed -e 's/\"lfc-interval\": 1/\"lfc-interval\": 2/g')
+    LFC_CONFIG=$(printf "${LFC_CONFIG}" | sed -e 's/\"lfc-interval\": 1/\"lfc-interval\": 2/g')
     # Create new configuration file.
     create_config "${LFC_CONFIG}"
 

--- a/src/bin/dhcp6/tests/dhcp6_process_tests.sh.in
+++ b/src/bin/dhcp6/tests/dhcp6_process_tests.sh.in
@@ -321,7 +321,7 @@ lfc_timer_test() {
     sleep 1
 
     # Modify the interval.
-    LFC_CONFIG=$(printf "${CONFIG}" | sed -e 's/\"lfc-interval\": 1/\"lfc-interval\": 2/g')
+    LFC_CONFIG=$(printf "${LFC_CONFIG}" | sed -e 's/\"lfc-interval\": 1/\"lfc-interval\": 2/g')
     # Create new configuration file.
     create_config "${LFC_CONFIG}"
 


### PR DESCRIPTION
Before change (IPv4):

```
INFO/test_lib: wait_for_message DHCPSRV_MEMFILE_LFC_EXECUTE: ...........
ERROR: Server did not execute LFC.
[...]
2016-09-25 14:02:28.988 INFO  [kea-dhcp4.dhcpsrv/53382] DHCPSRV_MEMFILE_DB opening memory file lease database: lfc-interval=1 name=/home/ports/pobj/kea-1.1.0-beta/kea-1.1.0-beta/src/bin/dhcp4/tests/test_leases.csv persist=true type=memfile universe=4
[...]
2016-09-25 14:02:31.092 INFO  [kea-dhcp4.dhcpsrv/53382] DHCPSRV_MEMFILE_DB opening memory file lease database: lfc-interval=0 name=/home/ports/pobj/kea-1.1.0-beta/kea-1.1.0-beta/src/bin/dhcp4/tests/test_leases.csv persist=false type=memfile universe=4
```

Before change (IPv6):

```
INFO/test_lib: wait_for_message DHCPSRV_MEMFILE_LFC_EXECUTE: ...........
ERROR: Server did not execute LFC.
[...]
2016-09-25 14:03:46.249 INFO  [kea-dhcp6.dhcpsrv/44306] DHCPSRV_MEMFILE_DB opening memory file lease database: lfc-interval=1 name=/home/ports/pobj/kea-1.1.0-beta/kea-1.1.0-beta/src/bin/dhcp6/tests/test_leases.csv persist=true type=memfile universe=6
[...]
2016-09-25 14:03:48.333 INFO  [kea-dhcp6.dhcpsrv/44306] DHCPSRV_MEMFILE_DB opening memory file lease database: lfc-interval=0 name=/home/ports/pobj/kea-1.1.0-beta/kea-1.1.0-beta/src/bin/dhcp6/tests/test_leases.csv persist=false type=memfile universe=6
```
