### PR TITLE
Fix system_messages helper path

### DIFF
--- a/doc/guide/Makefile.am
+++ b/doc/guide/Makefile.am
@@ -15,7 +15,7 @@ EXTRA_DIST = $(DOCBOOK)
 DISTCLEANFILES = $(HTMLDOCS) $(DOCS) kea-messages.xml
 
 kea-messages.xml:
-	$(top_srcdir)/tools/system_messages -o $@ \
+	$(top_builddir)/tools/system_messages -o $@ \
 	`find $(top_srcdir) -name "*.mes" -print`
 
 # This is not a "man" manual, but reuse this for now for docbook.


### PR DESCRIPTION
The path to system messages helper in doc/guide/Makefile.am is constructed
relative to $(top_srcdir) rather than $(top_builddir) which causes
out-of-source builds to fail.