### PR TITLE
Corrected spelling mistakes

### DIFF
--- a/doc/devel/contribute.dox
+++ b/doc/devel/contribute.dox
@@ -37,7 +37,7 @@ that your code compiles. This may seem obvious, but there's more to
 it. You have surely checked that it compiles on your system, but Kea
 is portable software. Besides Linux, it is compiled and used on
 relatively uncommon systems like OpenBSD. Will your code
-compile and work there? What about endianess? It is likely that you used
+compile and work there? What about endianness? It is likely that you used
 a regular x86 architecture machine to write your patch, but the software
 is expected to run on many other architectures. You may take a look at
 system specific build notes (http://kea.isc.org/wiki/Install).

--- a/doc/examples/kea4/backends.json
+++ b/doc/examples/kea4/backends.json
@@ -26,7 +26,7 @@
 
 # 2. MySQL backend. Leases will be stored in MySQL database. Make sure it
 # is up, running and properly initialized. See kea-admin documentation
-# for details on how to intialize the database. The only strictly required
+# for details on how to initialize the database. The only strictly required
 # parameters are type and name. If other parameters are not specified,
 # Kea will assume the database is avaiable on localhost, that user and
 # password is not necessary to connect and that timeout is 5 seconds.
@@ -42,7 +42,7 @@
 
 # 3. PostgreSQL backend. Leases will be stored in PostgreSQL database. Make
 # sure it is up, running and properly initialized. See kea-admin documentation
-# for details on how to intialize the database. The only strictly required
+# for details on how to initialize the database. The only strictly required
 # parameters are type and name. If other parameters are not specified,
 # Kea will assume the database is avaiable on localhost, that user and
 # password is not necessary to connect and that timeout is 5 seconds.
@@ -57,7 +57,7 @@
 
 # 4. CQL (Cassandra) backend. Leases will be stored in Cassandra database. Make
 # sure it is up, running and properly initialized. See kea-admin documentation
-# for details on how to intialize the database. The only strictly required
+# for details on how to initialize the database. The only strictly required
 # parameters are type, keyspace and contact_points. At least one contact point
 # must be specified, but more than one is required for redundancy. Make sure
 # you specify the contact points without spaces. Kea must be compiled with

--- a/doc/examples/kea6/backends.json
+++ b/doc/examples/kea6/backends.json
@@ -26,7 +26,7 @@
 
 # 2. MySQL backend. Leases will be stored in MySQL database. Make sure it
 # is up, running and properly initialized. See kea-admin documentation
-# for details on how to intialize the database. The only strictly required
+# for details on how to initialize the database. The only strictly required
 # parameters are type and name. If other parameters are not specified,
 # Kea will assume the database is avaiable on localhost, that user and
 # password is not necessary to connect and that timeout is 5 seconds.
@@ -42,7 +42,7 @@
 
 # 3. PostgreSQL backend. Leases will be stored in PostgreSQL database. Make
 # sure it is up, running and properly initialized. See kea-admin documentation
-# for details on how to intialize the database. The only strictly required
+# for details on how to initialize the database. The only strictly required
 # parameters are type and name. If other parameters are not specified,
 # Kea will assume the database is avaiable on localhost, that user and
 # password is not necessary to connect and that timeout is 5 seconds.
@@ -57,7 +57,7 @@
 
 # 4. CQL (Cassandra) backend. Leases will be stored in Cassandra database. Make
 # sure it is up, running and properly initialized. See kea-admin documentation
-# for details on how to intialize the database. The only strictly required
+# for details on how to initialize the database. The only strictly required
 # parameters are type, keyspace and contact_points. At least one contact point
 # must be specified, but more than one is required for redundancy. Make sure
 # you specify the contact points without spaces. Kea must be compiled with

--- a/doc/guide/admin.xml
+++ b/doc/guide/admin.xml
@@ -18,7 +18,7 @@
       For example, Kea currently only stores lease information
       and host reservations. Future versions of Kea will store
       additional data such as subnet definitions: the database
-      structure will need to be updated to accomdate the extra
+      structure will need to be updated to accommodate the extra
       information.
     </para>
 
@@ -72,7 +72,7 @@
         <listitem>
           <simpara>
             <command>lease-init</command> &mdash;
-            Initializes a new lease database. This is useful during a new 
+            Initializes a new lease database. This is useful during a new
             Kea installation. The database is initialized to the
             latest version supported by the version of the software being
             installed.
@@ -616,7 +616,7 @@ $ <userinput>kea-admin lease-upgrade pgsql -u <replaceable>database-user</replac
         <orderedlist>
           <listitem>
             <para>
-              Export CQLSH_HOST environemnt variable:
+              Export CQLSH_HOST environment variable:
 <screen>
 $ <userinput>export CQLSH_HOST=localhost</userinput>
 </screen>
@@ -715,7 +715,7 @@ $ <userinput>kea-admin lease-upgrade cql -n <replaceable>database-name</replacea
       read-only mode.
       Sections <xref linkend="read-only-database-configuration4"/> and
       <xref linkend="read-only-database-configuration6"/> describe when
-      such configuration may be reqired and how to configure Kea to
+      such configuration may be required and how to configure Kea to
       operate using a read-only host database.
       </para>
     </section>

--- a/doc/guide/classify.xml
+++ b/doc/guide/classify.xml
@@ -820,7 +820,7 @@ concatenation of the strings</entry></row>
      </para>
 
      <para>
-     To enable the debug statements in the classifciaton system you will
+     To enable the debug statements in the classification system you will
      need to set the severity to "DEBUG" and the debug level to at least 55.
      The specific loggers are "kea-dhcp4.eval" and "kea-dhcp6.eval".
      </para>

--- a/doc/guide/ctrl-channel.xml
+++ b/doc/guide/ctrl-channel.xml
@@ -104,7 +104,7 @@ where <command>/path/to/the/kea/socket</command> is the path specified in the
 configuration file. Text passed to <command>socat</command>
 will be sent to Kea and the responses received from Kea printed to standard output.</para>
 
-    <para>It is also easy to open UNIX socket programmatically. An example of
+    <para>It is also easy to open UNIX socket programatically. An example of
     such a simplistic client written in C is available in the Kea Developer's
     Guide, chapter Control Channel Overview, section Using Control Channel.</para>
 

--- a/doc/guide/ddns.xml
+++ b/doc/guide/ddns.xml
@@ -716,7 +716,7 @@ corresponding values in the DHCP servers' "dhcp-ddns" configuration section.
 
       </section> <!-- "d2-reverse-ddns-config" -->
 
-      <section id="d2-exmaple-config">
+      <section id="d2-example-config">
 	<title>Example DHCP-DDNS Server Configuration</title>
 	<para>
 	This section provides an example DHCP-DDNS server configuration based

--- a/doc/guide/dhcp4-srv.xml
+++ b/doc/guide/dhcp4-srv.xml
@@ -2969,7 +2969,7 @@ It is merely echoed by the server
 
 </screen>
 
-    <para>Static class assignments, as shown above, can be used in conjuction
+    <para>Static class assignments, as shown above, can be used in conjunction
     with classification using expressions.</para>
     </section>
 

--- a/doc/guide/dhcp6-srv.xml
+++ b/doc/guide/dhcp6-srv.xml
@@ -1203,7 +1203,7 @@ temporarily override a list of interface names and listen on all interfaces.
         S46 container options group rules and optional port parameters
         for a specified domain. There are three container options specified
         in the "dhcp6" (top level) option space: MAP-E Container option,
-        MAP-T Container option and S46 Lieghtweight 4over6 Container option.
+        MAP-T Container option and S46 Lightweight 4over6 Container option.
         These options only contain encapsulated options specified below.
         They do not include any data fields.
       </para>
@@ -2904,7 +2904,7 @@ should include options from the isc option space:
  }
 
 </screen>
-    <para>Static class assignments, as shown above, can be used in conjuction
+    <para>Static class assignments, as shown above, can be used in conjunction
     with classification using expressions.</para>
     </section>
 

--- a/doc/guide/hooks.xml
+++ b/doc/guide/hooks.xml
@@ -271,7 +271,7 @@
           </itemizedlist>
         </para>
         <para>
-          Once loaded, the library allows segregating incomings requests into
+          Once loaded, the library allows segregating incoming requests into
           known and unknown clients. For known clients, the packets are
           processed mostly as usual, except it is possible to override certain
           options being sent. That can be done on a per host basis. Clients
@@ -306,7 +306,7 @@
             is "HW_ADDR" for IPv4 users or "DUID" for IPv6
             users</para></listitem>
             <listitem><para><command>id</command>, whose value is
-            either the hardware address or the DUID from the equest
+            either the hardware address or the DUID from the request
             formatted as a string of hex digits, with or without
             ":" delimiters.</para></listitem>
           </itemizedlist>
@@ -344,7 +344,7 @@ and may have the zero or more of the following entries:
         <title>Forensic Logging Hooks</title>
         <para>
         This section describes the forensic log hooks library. This library
-        povides hooks that record a detailed log of lease assignments
+        provides hooks that record a detailed log of lease assignments
         and renewals into a set of log files.  Currently this library
         is only available to ISC customers with a support contract.
         </para>

--- a/doc/guide/logging.xml
+++ b/doc/guide/logging.xml
@@ -61,7 +61,7 @@
         runtime) are responsible for creating the loggers used by those
         libraries. Such loggers should have unique names, different
         from the logger names used by Kea. In this way the
-        messages output by the hooks library can be distingued from
+        messages output by the hooks library can be distinguished from
         messages issued by the core Kea code. Unique names also allow
         the loggers to be configured independently of loggers used
         by Kea.  Whenever it makes sense, a hook library can use multiple
@@ -150,7 +150,7 @@
           packet drops, you must create configuration entry for the
           logger called <quote>kea-dhcp4.bad-packets</quote> and specify
           severity DEBUG for this logger. All other configuration
-          parameters may be omited for this logger if the logger should
+          parameters may be omitted for this logger if the logger should
           use the default values specified in the root logger's
           configuration.
         </para>

--- a/ext/coroutine/coroutine.h
+++ b/ext/coroutine/coroutine.h
@@ -15,22 +15,22 @@
 // \brief Coroutine object
 //
 // A coroutine object maintains the state of a re-enterable routine.  It
-// is assignable and copy-constructable, and can be used as a base class
+// is assignable and copy-constructible, and can be used as a base class
 // for a class that uses it, or as a data member.  The copy overhead is
 // a single int.
 //
-// A reenterable function contains a CORO_REENTER (coroutine)  { ... }
+// A reentrant function contains a CORO_REENTER (coroutine)  { ... }
 // block.  Whenever an asychrnonous operation is initiated within the
 // routine, the function is provided as the handler object.  (The simplest
-// way to do this is to have the reenterable function be the operator()
+// way to do this is to have the reentrant function be the operator()
 // member for the coroutine object itself.)   For example:
-// 
+//
 //     CORO_YIELD socket->async_read_some(buffer, *this);
 //
 // The CORO_YIELD keyword updates the current status of the coroutine to
 // indicate the line number currently being executed.  The
 // async_read_some() call is initiated, with a copy of the updated
-// corotutine as its handler object, and the current coroutine exits.  When
+// coroutine as its handler object, and the current coroutine exits.  When
 // the async_read_some() call finishes, the copied coroutine will be
 // called, and will resume processing exactly where the original one left
 // off--right after asynchronous call.  This allows asynchronous I/O

--- a/src/bin/admin/tests/cql_tests.sh.in
+++ b/src/bin/admin/tests/cql_tests.sh.in
@@ -81,7 +81,7 @@ cql_lease_version_test() {
     $keaadmin lease-init cql -u $db_user -p $db_password -n $db_name -d $db_scripts_dir
     assert_eq 0 $? "kea-admin lease-init cql failed, expected exit code: %d, actual: %d"
 
-    # Verfiy that kea-admin lease-version returns the correct version.
+    # Verify that kea-admin lease-version returns the correct version.
     version=$($keaadmin lease-version cql -u $db_user -p $db_password -n $db_name)
     assert_str_eq "1.0" $version "Expected kea-admin to return %s, returned value was %s"
 

--- a/src/bin/admin/tests/mysql_tests.sh.in
+++ b/src/bin/admin/tests/mysql_tests.sh.in
@@ -38,7 +38,7 @@ mysql_lease_init_test() {
     # Let's wipe the whole database
     mysql_wipe
 
-    # Ok, now let's initalize the database
+    # Ok, now let's initialize the database
     ${keaadmin} lease-init mysql -u $db_user -p $db_password -n $db_name -d $db_scripts_dir
     ERRCODE=$?
 
@@ -117,7 +117,7 @@ mysql_host_reservation_init_test() {
     # Let's wipe the whole database
     mysql_wipe
 
-    # Ok, now let's initalize the database
+    # Ok, now let's initialize the database
     ${keaadmin} lease-init mysql -u $db_user -p $db_password -n $db_name -d $db_scripts_dir
     ERRCODE=$?
 
@@ -387,7 +387,7 @@ mysql_lease4_dump_test() {
     # Let's wipe the whole database
     mysql_wipe
 
-    # Ok, now let's initalize the database
+    # Ok, now let's initialize the database
     ${keaadmin} lease-init mysql -u $db_user -p $db_password -n $db_name -d $db_scripts_dir
     ERRCODE=$?
     assert_eq 0 $ERRCODE "could not create database, expected exit code %d, actual %d"
@@ -447,7 +447,7 @@ mysql_lease6_dump_test() {
     # Let's wipe the whole database
     mysql_wipe
 
-    # Ok, now let's initalize the database
+    # Ok, now let's initialize the database
     ${keaadmin} lease-init mysql -u $db_user -p $db_password -n $db_name -d $db_scripts_dir
     ERRCODE=$?
     assert_eq 0 $ERRCODE "could not create database, expected exit code %d, actual %d"

--- a/src/bin/admin/tests/pgsql_tests.sh.in
+++ b/src/bin/admin/tests/pgsql_tests.sh.in
@@ -86,7 +86,7 @@ pgsql_lease_version_test() {
     ${keaadmin} lease-init pgsql -u $db_user -p $db_password -n $db_name -d $db_scripts_dir
     assert_eq 0 $? "cannot initialize the database, expected exit code: %d, actual: %d"
 
-    # Verfiy that kea-admin lease-version returns the correct version
+    # Verify that kea-admin lease-version returns the correct version
     version=$(${keaadmin} lease-version pgsql -u $db_user -p $db_password -n $db_name)
     assert_str_eq "3.0" ${version} "Expected kea-admin to return %s, returned value was %s"
 
@@ -280,7 +280,7 @@ pgsql_lease4_dump_test() {
     # Let's wipe the whole database
     pgsql_wipe
 
-    # Ok, now let's initalize the database
+    # Ok, now let's initialize the database
     ${keaadmin} lease-init pgsql -u $db_user -p $db_password -n $db_name -d $db_scripts_dir
     ERRCODE=$?
     assert_eq 0 $ERRCODE "could not create database, expected exit code %d, actual %d"
@@ -375,7 +375,7 @@ pgsql_lease6_dump_test() {
     # Let's wipe the whole database
     pgsql_wipe
 
-    # Ok, now let's initalize the database
+    # Ok, now let's initialize the database
     ${keaadmin} lease-init pgsql -u $db_user -p $db_password -n $db_name -d $db_scripts_dir
     ERRCODE=$?
     assert_eq 0 $ERRCODE "could not create database,  status code %d"

--- a/src/bin/d2/d2_cfg_mgr.cc
+++ b/src/bin/d2/d2_cfg_mgr.cc
@@ -80,7 +80,7 @@ D2CfgMgr::forwardUpdatesEnabled() {
 
 bool
 D2CfgMgr::reverseUpdatesEnabled() {
-    // Reverse updates are not enabled if no revese servers are defined.
+    // Reverse updates are not enabled if no reverse servers are defined.
     return (getD2CfgContext()->getReverseMgr()->size() > 0);
 }
 

--- a/src/bin/d2/d2_config.cc
+++ b/src/bin/d2/d2_config.cc
@@ -130,7 +130,7 @@ operator<<(std::ostream& os, const D2Params& config) {
 }
 
 // *********************** TSIGKeyInfo  *************************
-// Note these values match correpsonding values for Bind9's
+// Note these values match corresponding values for Bind9's
 // dnssec-keygen
 const char* TSIGKeyInfo::HMAC_MD5_STR = "HMAC-MD5";
 const char* TSIGKeyInfo::HMAC_SHA1_STR = "HMAC-SHA1";

--- a/src/bin/d2/d2_config.h
+++ b/src/bin/d2/d2_config.h
@@ -258,7 +258,7 @@ private:
 /// @brief Dumps the contents of a D2Params as text to an output stream
 ///
 /// @param os output stream to which text should be sent
-/// @param config D2Param instnace to dump
+/// @param config D2Param instance to dump
 std::ostream&
 operator<<(std::ostream& os, const D2Params& config);
 
@@ -287,7 +287,7 @@ public:
     /// @brief Constructor
     ///
     /// @param name the unique label used to identify this key
-    /// @param algorithm the id of the encryption alogirthm this key uses.
+    /// @param algorithm the id of the encryption algorithm this key uses.
     /// Currently supported values are (case insensitive):
     /// -# "HMAC-MD5"
     /// -# "HMAC-SHA1"
@@ -538,7 +538,7 @@ public:
     ///
     /// @param name is the domain name of the domain.
     /// @param servers is the list of server(s) supporting this domain.
-    /// @param tsig_key_info pointer to the TSIGKeyInfo for the dommain's key
+    /// @param tsig_key_info pointer to the TSIGKeyInfo for the domain's key
     /// It defaults to an empty pointer, signifying the domain has no key.
     DdnsDomain(const std::string& name,
                DnsServerInfoStoragePtr servers,

--- a/src/bin/d2/d2_process.cc
+++ b/src/bin/d2/d2_process.cc
@@ -243,7 +243,7 @@ D2Process::checkQueueStatus() {
                                                  : "shutdown");
                 queue_mgr_->stopListening();
             } catch (const isc::Exception& ex) {
-                // It is very unlikey that we would experience an error
+                // It is very unlikely that we would experience an error
                 // here, but theoretically possible.
                 LOG_ERROR(d2_logger, DHCP_DDNS_QUEUE_MGR_STOP_ERROR)
                           .arg(ex.what());

--- a/src/bin/d2/d2_process.h
+++ b/src/bin/d2/d2_process.h
@@ -66,9 +66,9 @@ public:
     /// This is invoked by the controller after command line arguments but
     /// PRIOR to configuration reception.  The base class provides this method
     /// as a place to perform any derivation-specific initialization steps
-    /// that are inapppropriate for the constructor but necessary prior to
+    /// that are inappropriate for the constructor but necessary prior to
     /// launch.  So far, no such steps have been identified for D2, so its
-    /// implementantion is empty but required.
+    /// implementation is empty but required.
     ///
     /// @throw DProcessBaseError if the initialization fails.
     virtual void init();

--- a/src/bin/d2/d2_queue_mgr.cc
+++ b/src/bin/d2/d2_queue_mgr.cc
@@ -153,7 +153,7 @@ D2QueueMgr::stopListening(const State target_stop_state) {
                       << target_stop_state);
         }
 
-        // Remember the state we want to acheive.
+        // Remember the state we want to achieve.
         target_stop_state_ = target_stop_state;
 
         // Instruct the listener to stop.  If the listener reports that  it

--- a/src/bin/d2/d2_update_message.cc
+++ b/src/bin/d2/d2_update_message.cc
@@ -128,7 +128,7 @@ D2UpdateMessage::fromWire(const void* received_data, size_t bytes_received,
     isc::util::InputBuffer received_data_buffer(received_data, bytes_received);
     message_.fromWire(received_data_buffer);
 
-    // If tsig_contex is not NULL, then we need to verify the message.
+    // If tsig_context is not NULL, then we need to verify the message.
     if (tsig_context) {
         TSIGError error = tsig_context->verify(message_.getTSIGRecord(),
                                                received_data, bytes_received);

--- a/src/bin/d2/d2_update_message.h
+++ b/src/bin/d2/d2_update_message.h
@@ -56,7 +56,7 @@ public:
         isc::Exception(file, line, what) {}
 };
 
-/// @brief Exception indicating that a signed, inbound message failed to verfiy
+/// @brief Exception indicating that a signed, inbound message failed to verify
 ///
 /// This exception is thrown when TSIG verification of a DNS server's response
 /// fails.

--- a/src/bin/d2/dns_client.cc
+++ b/src/bin/d2/dns_client.cc
@@ -46,7 +46,7 @@ public:
     // received. This allows a single DNSClientImpl instance to be used for
     // multiple, sequential IOFetch calls. (@todo Trac# 3286 has been opened
     // against dns::Message::fromWire.  Should the behavior of fromWire change
-    // the behavior here with could be rexamined).
+    // the behavior here with could be reexamined).
     D2UpdateMessagePtr& response_;
     // A caller-supplied external callback which is invoked when DNS message
     // exchange is complete or interrupted.

--- a/src/bin/d2/dns_client.h
+++ b/src/bin/d2/dns_client.h
@@ -85,7 +85,7 @@ public:
 
     /// @brief Constructor.
     ///
-    /// @param response_placeholder Messge object pointer which will be updated
+    /// @param response_placeholder Message object pointer which will be updated
     /// with dynamically allocated object holding the DNS server's response.
     /// @param callback Pointer to an object implementing @c DNSClient::Callback
     /// class. This object will be called when DNS message exchange completes or

--- a/src/bin/d2/nc_remove.h
+++ b/src/bin/d2/nc_remove.h
@@ -212,7 +212,7 @@ protected:
     /// post a next event of IO_COMPLETED_EVT and then invoke runModel which
     /// resumes execution of the state model.
     ///
-    /// When the handler is invoked with a next event of IO_COMPELTED_EVT,
+    /// When the handler is invoked with a next event of IO_COMPLETED_EVT,
     /// the DNS update status is checked and acted upon accordingly:
     ///
     /// Transitions to:
@@ -254,7 +254,7 @@ protected:
     /// post a next event of IO_COMPLETED_EVT and then invoke runModel which
     /// resumes execution of the state model.
     ///
-    /// When the handler is invoked with a next event of IO_COMPELTED_EVT,
+    /// When the handler is invoked with a next event of IO_COMPLETED_EVT,
     /// the DNS update status is checked and acted upon accordingly:
     ///
     /// Transitions to:
@@ -306,7 +306,7 @@ protected:
     /// post a next event of IO_COMPLETED_EVT and then invoke runModel which
     /// resumes execution of the state model.
     ///
-    /// When the handler is invoked with a next event of IO_COMPELTED_EVT,
+    /// When the handler is invoked with a next event of IO_COMPLETED_EVT,
     /// the DNS update status is checked and acted upon accordingly:
     ///
     /// Transitions to:

--- a/src/bin/d2/nc_trans.h
+++ b/src/bin/d2/nc_trans.h
@@ -144,7 +144,7 @@ public:
     static const int NCT_DERIVED_EVENT_MIN = SM_DERIVED_EVENT_MIN + 101;
     //@}
 
-    /// @brief Defualt time to assign to a single DNS udpate.
+    /// @brief Default time to assign to a single DNS update.
     /// @todo  This value will be made configurable in the very near future
     /// under trac3268. For now we will define it to 100 milliseconds
     /// so unit tests will run within a reasonable amount of time.
@@ -289,7 +289,7 @@ protected:
     void setDnsUpdateRequest(D2UpdateMessagePtr& request);
 
     /// @brief Destroys the current update request packet and resets
-    /// udpate attempts count.
+    /// update attempts count.
     void clearDnsUpdateRequest();
 
     /// @brief Sets the update status to the given status value.

--- a/src/bin/d2/tests/d2_cfg_mgr_unittests.cc
+++ b/src/bin/d2/tests/d2_cfg_mgr_unittests.cc
@@ -65,7 +65,7 @@ public:
 
     /// @brief Build JSON configuration string for a D2Params element
     ///
-    /// Constructs a JSON string for "params" element using replacable
+    /// Constructs a JSON string for "params" element using replaceable
     /// parameters.
     ///
     /// @param ip_address string to insert as ip_address value
@@ -509,7 +509,7 @@ TEST_F(D2CfgMgrTest, unsupportedTopLevelItems) {
 /// -# ip_address cannot be "0.0.0.0"
 /// -# ip_address cannot be "::"
 /// -# port cannot be 0
-/// -# dns_server_timeout cannat be 0
+/// -# dns_server_timeout cannot be 0
 /// -# ncr_protocol must be valid
 /// -# ncr_format must be valid
 TEST_F(D2CfgMgrTest, invalidEntry) {
@@ -940,7 +940,7 @@ TEST_F(ConfigParseTest, validServerList) {
     isc::dhcp::ParserPtr parser;
     ASSERT_NO_THROW(parser.reset(new DnsServerInfoListParser("test", servers)));
 
-    // Verfiy that the list builds and commits without error.
+    // Verify that the list builds and commits without error.
     ASSERT_NO_THROW(parser->build(config_set_));
     ASSERT_NO_THROW(parser->commit());
 
@@ -1443,7 +1443,7 @@ TEST_F(D2CfgMgrTest, forwardMatch) {
     EXPECT_TRUE(cfg_mgr_->matchForward("tmark.org", match));
     EXPECT_EQ("tmark.org", match->getName());
 
-    // Verify that search is case insensisitive.
+    // Verify that search is case-insensitive.
     EXPECT_TRUE(cfg_mgr_->matchForward("TMARK.ORG", match));
     EXPECT_EQ("tmark.org", match->getName());
 

--- a/src/bin/d2/tests/d2_controller_unittests.cc
+++ b/src/bin/d2/tests/d2_controller_unittests.cc
@@ -149,7 +149,7 @@ TEST_F(D2ControllerTest, launchNormalShutdown) {
     time_duration elapsed_time;
     runWithConfig(valid_d2_config, 1000, elapsed_time);
 
-    // Give a generous margin to accomodate slower test environs.
+    // Give a generous margin to accommodate slower test environs.
     EXPECT_TRUE(elapsed_time.total_milliseconds() >= 800 &&
                 elapsed_time.total_milliseconds() <= 1300);
 }
@@ -294,7 +294,7 @@ TEST_F(D2ControllerTest, sigintShutdown) {
     runWithConfig(valid_d2_config, 1000, elapsed_time);
 
     // Signaled shutdown should make our elapsed time much smaller than
-    // the maximum run time.  Give generous margin to accomodate slow
+    // the maximum run time.  Give generous margin to accommodate slow
     // test environs.
     EXPECT_TRUE(elapsed_time.total_milliseconds() < 300);
 
@@ -311,7 +311,7 @@ TEST_F(D2ControllerTest, sigtermShutdown) {
     runWithConfig(valid_d2_config, 1000, elapsed_time);
 
     // Signaled shutdown should make our elapsed time much smaller than
-    // the maximum run time.  Give generous margin to accomodate slow
+    // the maximum run time.  Give generous margin to accommodate slow
     // test environs.
     EXPECT_TRUE(elapsed_time.total_milliseconds() < 300);
 

--- a/src/bin/d2/tests/d2_queue_mgr_unittests.cc
+++ b/src/bin/d2/tests/d2_queue_mgr_unittests.cc
@@ -176,11 +176,11 @@ TEST(D2QueueMgrBasicTest, basicQueue) {
     // Verify queue count is correct.
     EXPECT_EQ(VALID_MSG_CNT, queue_mgr->getQueueSize());
 
-    // Verfiy that peekAt returns the correct entry.
+    // Verify that peekAt returns the correct entry.
     EXPECT_NO_THROW(ncr = queue_mgr->peekAt(1));
     EXPECT_TRUE (*(ref_msgs[1]) == *ncr);
 
-    // Verfiy that dequeueAt removes the correct entry.
+    // Verify that dequeueAt removes the correct entry.
     // Removing it, this should shift the queued entries forward by one.
     EXPECT_NO_THROW(queue_mgr->dequeueAt(1));
     EXPECT_NO_THROW(ncr = queue_mgr->peekAt(1));

--- a/src/bin/d2/tests/d2_update_message_unittests.cc
+++ b/src/bin/d2/tests/d2_update_message_unittests.cc
@@ -282,7 +282,7 @@ TEST_F(D2UpdateMessageTest, fromWireInvalidOpcode) {
     };
     // The 'true' argument passed to the constructor turns the
     // message into the parse mode in which the fromWire function
-    // can be used to decode the binary mesasage data.
+    // can be used to decode the binary message data.
     D2UpdateMessage msg(D2UpdateMessage::INBOUND);
     // When using invalid Opcode, the fromWire function should
     // throw NotUpdateMessage exception.
@@ -306,7 +306,7 @@ TEST_F(D2UpdateMessageTest, fromWireInvalidQRFlag) {
     };
     // The 'true' argument passed to the constructor turns the
     // message into the parse mode in which the fromWire function
-    // can be used to decode the binary mesasage data.
+    // can be used to decode the binary message data.
     D2UpdateMessage msg(D2UpdateMessage::INBOUND);
     // When using invalid QR flag, the fromWire function should
     // throw InvalidQRFlag exception.
@@ -345,7 +345,7 @@ TEST_F(D2UpdateMessageTest, fromWireTooManyZones) {
 
     // The 'true' argument passed to the constructor turns the
     // message into the parse mode in which the fromWire function
-    // can be used to decode the binary mesasage data.
+    // can be used to decode the binary message data.
     D2UpdateMessage msg(D2UpdateMessage::INBOUND);
     // When parsing a message with more than one Zone record,
     // exception should be thrown.
@@ -366,7 +366,7 @@ TEST_F(D2UpdateMessageTest, toWire) {
     // one Zone. toWire function would fail if Zone is not set.
     msg.setZone(Name("example.com"), RRClass::IN());
 
-    // Set prerequisities.
+    // Set prerequisites.
 
     // 'Name Is Not In Use' prerequisite (RFC 2136, section 2.4.5)
     RRsetPtr prereq1(new RRset(Name("foo.example.com"), RRClass::NONE(),
@@ -433,7 +433,7 @@ TEST_F(D2UpdateMessageTest, toWire) {
     EXPECT_EQ(1, buf.readUint16());
 
     // PRCOUNT - holds the number of prerequisites. Earlier we have added
-    // two prerequisites. Thus, expect that this conter is 2.
+    // two prerequisites. Thus, expect that this counter is 2.
     EXPECT_EQ(2, buf.readUint16());
 
     // UPCOUNT - holds the number of RRs in the Update Section. We have
@@ -484,7 +484,7 @@ TEST_F(D2UpdateMessageTest, toWire) {
 
     // Check the name first. Message renderer is using compression for domain
     // names as described in RFC 1035, section 4.1.4. The name in this RR is
-    // foo.example.com. The name of the zone is example.com and it has occured
+    // foo.example.com. The name of the zone is example.com and it has occurred
     // in this message already at offset 12 (the size of the header is 12).
     // Therefore, name of this RR is encoded as 'foo', followed by a pointer
     // to offset in this message where the remainder of this name was used.
@@ -566,7 +566,7 @@ TEST_F(D2UpdateMessageTest, toWireInvalidQRFlag) {
 
     // The 'true' argument passed to the constructor turns the
     // message into the parse mode in which the fromWire function
-    // can be used to decode the binary mesasage data.
+    // can be used to decode the binary message data.
     D2UpdateMessage msg(D2UpdateMessage::INBOUND);
     ASSERT_NO_THROW(msg.fromWire(bin_msg, sizeof(bin_msg)));
 

--- a/src/bin/d2/tests/dns_client_unittests.cc
+++ b/src/bin/d2/tests/dns_client_unittests.cc
@@ -219,7 +219,7 @@ public:
         dns::Message request(Message::PARSE);
         request.fromWire(received_data_buffer);
 
-        // If contex is not NULL, then we need to verify the message.
+        // If context is not NULL, then we need to verify the message.
         if (context) {
             TSIGError error = context->verify(request.getTSIGRecord(),
                                               receive_buffer_, receive_length);
@@ -502,7 +502,7 @@ TEST_F(DNSClientTest, runTSIGTest) {
     // Neither client nor server will attempt to sign or verify.
     runTSIGTest(nokey, nokey);
 
-    // Client signs the request, server verfies but doesn't sign.
+    // Client signs the request, server verifies but doesn't sign.
     runTSIGTest(key_one, nokey, false);
 
     // Client and server use the same key to sign and verify.

--- a/src/bin/d2/tests/nc_add_unittests.cc
+++ b/src/bin/d2/tests/nc_add_unittests.cc
@@ -24,7 +24,7 @@ using namespace isc::util;
 
 namespace {
 
-/// @brief Test class derived from NameAddTransaction to provide visiblity
+/// @brief Test class derived from NameAddTransaction to provide visibility
 // to protected methods.
 class NameAddStub : public NameAddTransaction {
 public:
@@ -1030,7 +1030,7 @@ TEST_F(NameAddTransactionTest, replacingFwdAddrsHandler_OtherRcode) {
     EXPECT_FALSE(name_add->getForwardChangeCompleted());
     EXPECT_FALSE(name_add->getReverseChangeCompleted());
 
-    // We should have failed the transaction. Verifiy that we transitioned
+    // We should have failed the transaction. Verify that we transitioned
     // correctly.
     EXPECT_EQ(NameChangeTransaction::PROCESS_TRANS_FAILED_ST,
               name_add->getCurrState());

--- a/src/bin/d2/tests/nc_remove_unittests.cc
+++ b/src/bin/d2/tests/nc_remove_unittests.cc
@@ -25,7 +25,7 @@ using namespace isc::util;
 
 namespace {
 
-/// @brief Test class derived from NameRemoveTransaction to provide visiblity
+/// @brief Test class derived from NameRemoveTransaction to provide visibility
 // to protected methods.
 class NameRemoveStub : public NameRemoveTransaction {
 public:
@@ -969,7 +969,7 @@ TEST_F(NameRemoveTransactionTest, removingFwdRRsHandler_FqdnNotInUse) {
     // Run removingFwdRRsHandler again to process the response.
     EXPECT_NO_THROW(name_remove->removingFwdRRsHandler());
 
-    // Forwad completion flag should be true, reverse should still be false.
+    // Forward completion flag should be true, reverse should still be false.
     EXPECT_TRUE(name_remove->getForwardChangeCompleted());
     EXPECT_FALSE(name_remove->getReverseChangeCompleted());
 
@@ -1016,7 +1016,7 @@ TEST_F(NameRemoveTransactionTest, removingFwdRRsHandler_OtherRcode) {
     EXPECT_FALSE(name_remove->getForwardChangeCompleted());
     EXPECT_FALSE(name_remove->getReverseChangeCompleted());
 
-    // We should have failed the transaction. Verifiy that we transitioned
+    // We should have failed the transaction. Verify that we transitioned
     // correctly.
     EXPECT_EQ(NameChangeTransaction::PROCESS_TRANS_FAILED_ST,
               name_remove->getCurrState());

--- a/src/bin/d2/tests/nc_test_utils.cc
+++ b/src/bin/d2/tests/nc_test_utils.cc
@@ -107,7 +107,7 @@ FauxServer::requestHandler(const boost::system::error_code& error,
     try {
         request.fromWire(request_buf);
 
-        // If contex is not NULL, then we need to verify the message.
+        // If context is not NULL, then we need to verify the message.
         if (context) {
             dns::TSIGError error = context->verify(request.getTSIGRecord(),
                                                    receive_buffer_,

--- a/src/bin/d2/tests/nc_test_utils.h
+++ b/src/bin/d2/tests/nc_test_utils.h
@@ -36,7 +36,7 @@ public:
     enum  ResponseMode {
         USE_RCODE,    // Generate a response with a given RCODE
         CORRUPT_RESP, // Generate a corrupt response
-        INVALID_TSIG  // Generate a repsonse with the wrong TSIG key
+        INVALID_TSIG  // Generate a response with the wrong TSIG key
     };
 
     // Reference to IOService to use for IO processing.

--- a/src/bin/d2/tests/nc_trans_unittests.cc
+++ b/src/bin/d2/tests/nc_trans_unittests.cc
@@ -66,7 +66,7 @@ public:
 
     /// @brief DNSClient callback
     /// Overrides the callback in NameChangeTranscation to allow testing
-    /// sendUpdate without incorporating exectution of the state model
+    /// sendUpdate without incorporating execution of the state model
     /// into the test.
     /// It sets the DNS status update and posts IO_COMPLETED_EVT as does
     /// the normal callback.
@@ -313,7 +313,7 @@ public:
     /// @brief Builds and then sends an update request
     ///
     /// This method is used to build and send and update request. It is used
-    /// in conjuction with FauxServer to test various message response
+    /// in conjunction with FauxServer to test various message response
     /// scenarios.
     /// @param name_change Transaction under test
     /// @param run_time Maximum time to permit IO processing to run before
@@ -824,7 +824,7 @@ TEST_F(NameChangeTransactionTest, successfulUpdateTest) {
     EXPECT_TRUE(name_change->getForwardChangeCompleted());
 }
 
-/// @brief Tests the ability to use startTransaction to initate the state
+/// @brief Tests the ability to use startTransaction to initiate the state
 /// model execution, and DNSClient callback, operator(), to resume the
 /// model with a update failure outcome.
 TEST_F(NameChangeTransactionTest, failedUpdateTest) {
@@ -1043,7 +1043,7 @@ TEST_F(NameChangeTransactionTest, tsigUnsignedResponse) {
     FauxServer server(*io_service_, *(name_change->getCurrentServer()));
     server.receive (FauxServer::USE_RCODE, dns::Rcode::NOERROR());
 
-    // Do the udpate.
+    // Do the update.
     ASSERT_NO_FATAL_FAILURE(doOneExchange(name_change));
 
     // Verify that next event is IO_COMPLETED_EVT and DNS status is
@@ -1074,7 +1074,7 @@ TEST_F(NameChangeTransactionTest, tsigInvalidResponse) {
     FauxServer server(*io_service_, *(name_change->getCurrentServer()));
     server.receive (FauxServer::INVALID_TSIG, dns::Rcode::NOERROR());
 
-    // Do the udpate.
+    // Do the update.
     ASSERT_NO_FATAL_FAILURE(doOneExchange(name_change));
 
     // Verify that next event is IO_COMPLETED_EVT and DNS status is
@@ -1124,7 +1124,7 @@ TEST_F(NameChangeTransactionTest, tsigUnexpectedSignedResponse) {
     EXPECT_EQ("response.example.com.", zone->getName().toText());
 }
 
-/// @brief Tests that a TSIG udpate succeeds when client and server both use
+/// @brief Tests that a TSIG update succeeds when client and server both use
 /// the right key.  Runs the test for all supported algorithms.
 TEST_F(NameChangeTransactionTest, tsigAllValid) {
     std::vector<std::string>algorithms;

--- a/src/bin/dhcp4/ctrl_dhcp4_srv.h
+++ b/src/bin/dhcp4/ctrl_dhcp4_srv.h
@@ -168,7 +168,7 @@ private:
     /// this method.
     ///
     /// @param max_leases Maximum number of leases to be reclaimed.
-    /// @param timeout Maximum amount of time that the reclaimation routine
+    /// @param timeout Maximum amount of time that the reclamation routine
     /// may be processing expired leases, expressed in milliseconds.
     /// @param remove_lease A boolean value indicating if the lease should
     /// be removed when it is reclaimed (if true) or it should be left in the

--- a/src/bin/dhcp4/dhcp4_srv.cc
+++ b/src/bin/dhcp4/dhcp4_srv.cc
@@ -899,7 +899,7 @@ Dhcpv4Srv::processPacket(Pkt4Ptr& query, Pkt4Ptr& rsp) {
                 .arg(query->getIface())
                 .arg(e.what());
 
-            // Increase the statistics of parse failues and dropped packets.
+            // Increase the statistics of parse failures and dropped packets.
             isc::stats::StatsMgr::instance().addValue("pkt4-parse-failed",
                                                       static_cast<int64_t>(1));
             isc::stats::StatsMgr::instance().addValue("pkt4-receive-drop",
@@ -2044,7 +2044,7 @@ Dhcpv4Srv::setFixedFields(Dhcpv4Exchange& ex) {
             getClientClassDictionary()->getClasses();
 
         // Now we need to iterate over the classes assigned to the
-        // query packet and find corresponding class defintions for it.
+        // query packet and find corresponding class definitions for it.
         for (ClientClasses::const_iterator name = classes.begin();
              name != classes.end(); ++name) {
 
@@ -2065,18 +2065,18 @@ Dhcpv4Srv::setFixedFields(Dhcpv4Exchange& ex) {
             const string& sname = cl->second->getSname();
             if (!sname.empty()) {
                 // Converting string to (const uint8_t*, size_t len) format is
-                // tricky. reineterpret_cast is not the most elegant solution,
+                // tricky. reinterpret_cast is not the most elegant solution,
                 // but it does avoid us making unnecessary copy. We will convert
                 // sname and file fields in Pkt4 to string one day and life
                 // will be easier.
                 response->setSname(reinterpret_cast<const uint8_t*>(sname.c_str()),
                                    sname.size());
             }
-            
+
             const string& filename = cl->second->getFilename();
             if (!filename.empty()) {
                 // Converting string to (const uint8_t*, size_t len) format is
-                // tricky. reineterpret_cast is not the most elegant solution,
+                // tricky. reinterpret_cast is not the most elegant solution,
                 // but it does avoid us making unnecessary copy. We will convert
                 // sname and file fields in Pkt4 to string one day and life
                 // will be easier.

--- a/src/bin/dhcp4/json_config_parser.cc
+++ b/src/bin/dhcp4/json_config_parser.cc
@@ -334,7 +334,7 @@ protected:
             subnet4->get4o6().enabled(true);
         }
 
-        // Try 4o6 specific paramter: 4o6-interface-id
+        // Try 4o6 specific parameter: 4o6-interface-id
         std::string ifaceid = string_values_->getOptionalParam("4o6-interface-id", "");
         if (!ifaceid.empty()) {
             OptionBuffer tmp(ifaceid.begin(), ifaceid.end());

--- a/src/bin/dhcp4/tests/classify_unittest.cc
+++ b/src/bin/dhcp4/tests/classify_unittest.cc
@@ -138,7 +138,7 @@ public:
         IfaceMgr::instance().openSockets4();
     }
 
-    /// @brief Desctructor.
+    /// @brief Destructor.
     ///
     ~ClassifyTest() {
     }

--- a/src/bin/dhcp4/tests/config_parser_unittest.cc
+++ b/src/bin/dhcp4/tests/config_parser_unittest.cc
@@ -2443,7 +2443,7 @@ TEST_F(Dhcp4ParserTest, optionDataBoolean) {
                       sizeof(expected_option_data));
 
     // Bogus values should not be accepted.
-    params["data"] = "bugus";
+    params["data"] = "bogus";
     testInvalidOptionParam(params);
 
     params["data"] = "2";
@@ -3239,7 +3239,7 @@ TEST_F(Dhcp4ParserTest, selectedInterfacesAndAddresses) {
 TEST_F(Dhcp4ParserTest, d2ClientConfig) {
     ConstElementPtr status;
 
-    // Verify that the D2 configuraiton can be fetched and is set to disabled.
+    // Verify that the D2 configuration can be fetched and is set to disabled.
     D2ClientConfigPtr d2_client_config = CfgMgr::instance().getD2ClientConfig();
     EXPECT_FALSE(d2_client_config->getEnableUpdates());
 
@@ -3343,7 +3343,7 @@ TEST_F(Dhcp4ParserTest, invalidD2ClientConfig) {
     checkResult(status, 1);
     EXPECT_TRUE(errorContainsPosition(status, "<string>"));
 
-    // Verify that the D2 configuraiton can be fetched and is set to disabled.
+    // Verify that the D2 configuration can be fetched and is set to disabled.
     D2ClientConfigPtr d2_client_config = CfgMgr::instance().getD2ClientConfig();
     EXPECT_FALSE(d2_client_config->getEnableUpdates());
 
@@ -4152,7 +4152,7 @@ TEST_F(Dhcp4ParserTest, 4o6subnetBogus) {
         "    \"4o6-subnet\": \"2001:db8:bogus/45\" } ],"
         "\"valid-lifetime\": 4000 }",
 
-        // Bogus configuration 3: incorrect prefix lenght
+        // Bogus configuration 3: incorrect prefix length
         "{ " + genIfaceConfig() + "," +
         "\"rebind-timer\": 2000, "
         "\"renew-timer\": 1000, "

--- a/src/bin/dhcp4/tests/ctrl_dhcp4_srv_unittest.cc
+++ b/src/bin/dhcp4/tests/ctrl_dhcp4_srv_unittest.cc
@@ -394,7 +394,7 @@ TEST_F(CtrlChannelDhcpv4SrvTest, controlLeasesReclaim) {
     EXPECT_TRUE(lease1->stateExpiredReclaimed());
 }
 
-// Thist test verifies that the DHCP server immediately removed expired
+// This test verifies that the DHCP server immediately removed expired
 // leases on leases-reclaim command with remove = true
 TEST_F(CtrlChannelDhcpv4SrvTest, controlLeasesReclaimRemove) {
     createUnixChannelServer();

--- a/src/bin/dhcp4/tests/decline_unittest.cc
+++ b/src/bin/dhcp4/tests/decline_unittest.cc
@@ -89,7 +89,7 @@ Dhcpv4SrvTest::acquireAndDecline(Dhcp4Client& client,
     isc::stats::StatsMgr::instance().setValue("declined-addresses",
                                               static_cast<int64_t>(0));
 
-    // Ok, do the normal lease aquisition.
+    // Ok, do the normal lease acquisition.
     CfgMgr::instance().clear();
 
     // Configure DHCP server.
@@ -149,7 +149,7 @@ Dhcpv4SrvTest::acquireAndDecline(Dhcp4Client& client,
     if (expected_result == SHOULD_PASS) {
         EXPECT_EQ(Lease::STATE_DECLINED, lease->state_);
 
-        // The decline succeded, so the declined-addresses statistic should
+        // The decline succeeded, so the declined-addresses statistic should
         // be increased by one
         EXPECT_EQ(after, before + 1);
 

--- a/src/bin/dhcp4/tests/dhcp4_client.cc
+++ b/src/bin/dhcp4/tests/dhcp4_client.cc
@@ -186,7 +186,7 @@ Dhcp4Client::applyConfiguration() {
     // sname
     OptionBuffer buf = resp->getSname();
     // sname is a fixed length field holding null terminated string. Use
-    // of c_str() guarantess that only a useful portion (ending with null
+    // of c_str() guarantees that only a useful portion (ending with null
     // character) is assigned.
     config_.sname_.assign(std::string(buf.begin(), buf.end()).c_str());
     // (boot)file

--- a/src/bin/dhcp4/tests/dhcp4_srv_unittest.cc
+++ b/src/bin/dhcp4/tests/dhcp4_srv_unittest.cc
@@ -2431,7 +2431,7 @@ TEST_F(Dhcpv4SrvTest, statisticsDecline) {
 }
 
 // Test checks whether statistic is bumped up appropriately when Offer
-// message is received (this should never happen in a sane metwork).
+// message is received (this should never happen in a sane network).
 TEST_F(Dhcpv4SrvTest, statisticsOfferRcvd) {
     NakedDhcpv4Srv srv(0);
 
@@ -2439,7 +2439,7 @@ TEST_F(Dhcpv4SrvTest, statisticsOfferRcvd) {
 }
 
 // Test checks whether statistic is bumped up appropriately when Ack
-// message is received (this should never happen in a sane metwork).
+// message is received (this should never happen in a sane network).
 TEST_F(Dhcpv4SrvTest, statisticsAckRcvd) {
     NakedDhcpv4Srv srv(0);
 
@@ -2447,7 +2447,7 @@ TEST_F(Dhcpv4SrvTest, statisticsAckRcvd) {
 }
 
 // Test checks whether statistic is bumped up appropriately when Nak
-// message is received (this should never happen in a sane metwork).
+// message is received (this should never happen in a sane network).
 TEST_F(Dhcpv4SrvTest, statisticsNakRcvd) {
     NakedDhcpv4Srv srv(0);
 

--- a/src/bin/dhcp4/tests/dhcp4_test_utils.cc
+++ b/src/bin/dhcp4/tests/dhcp4_test_utils.cc
@@ -662,7 +662,7 @@ Dhcpv4SrvTest::pretendReceivingPkt(NakedDhcpv4Srv& srv, const std::string& confi
     ObservationPtr pkt4_rcvd = mgr.getObservation("pkt4-received");
     ObservationPtr tested_stat = mgr.getObservation(stat_name);
 
-    // All expected statstics must be present.
+    // All expected statistics must be present.
     ASSERT_TRUE(pkt4_rcvd);
     ASSERT_TRUE(tested_stat);
 

--- a/src/bin/dhcp4/tests/dhcp4_test_utils.h
+++ b/src/bin/dhcp4/tests/dhcp4_test_utils.h
@@ -421,7 +421,7 @@ public:
     ///
     /// Instantiates fake network interfaces, configures passed Dhcpv4Srv,
     /// then creates a message of specified type and sends it to the
-    /// server and then checks whether expected statstics were set
+    /// server and then checks whether expected statistics were set
     /// appropriately.
     ///
     /// @param srv the DHCPv4 server to be used

--- a/src/bin/dhcp4/tests/dora_unittest.cc
+++ b/src/bin/dhcp4/tests/dora_unittest.cc
@@ -355,7 +355,7 @@ public:
         isc::stats::StatsMgr::instance().removeAll();
     }
 
-    /// @brief Desctructor.
+    /// @brief Destructor.
     ///
     /// Cleans up statistics after the test.
     ~DORATest() {
@@ -609,7 +609,7 @@ TEST_F(DORATest, initRebootRequest) {
     EXPECT_EQ(DHCPNAK, static_cast<int>(resp->getType()));
 
     // Change client identifier. The server should treat the request
-    // as a resquest from unknown client and ignore it.
+    // as a request from unknown client and ignore it.
     client.includeClientId("12:34");
     ASSERT_NO_THROW(client.doRequest());
     ASSERT_FALSE(client.getContext().response_);
@@ -1315,7 +1315,7 @@ TEST_F(DORATest, reservationsWithConflicts) {
 
     // Client A performs 4-way exchange.
     client.setState(Dhcp4Client::SELECTING);
-    // Revert to the broadcast address for the selcting client.
+    // Revert to the broadcast address for the selecting client.
     client.setDestAddress(IOAddress::IPV4_BCAST_ADDRESS());
     // Obtain a lease from the server using the 4-way exchange.
     ASSERT_NO_THROW(client.doDORA(boost::shared_ptr<
@@ -1379,7 +1379,7 @@ TEST_F(DORATest, statisticsDORA) {
     ObservationPtr pkt4_ack_sent = mgr.getObservation("pkt4-ack-sent");
     ObservationPtr pkt4_sent = mgr.getObservation("pkt4-sent");
 
-    // All expected statstics must be present.
+    // All expected statistics must be present.
     ASSERT_TRUE(pkt4_received);
     ASSERT_TRUE(pkt4_discover_received);
     ASSERT_TRUE(pkt4_offer_sent);
@@ -1441,7 +1441,7 @@ TEST_F(DORATest, statisticsNAK) {
     ObservationPtr pkt4_nak_sent = mgr.getObservation("pkt4-nak-sent");
     ObservationPtr pkt4_sent = mgr.getObservation("pkt4-sent");
 
-    // All expected statstics must be present.
+    // All expected statistics must be present.
     ASSERT_TRUE(pkt4_received);
     ASSERT_TRUE(pkt4_request_received);
     ASSERT_FALSE(pkt4_ack_sent); // No acks were sent, no such statistic expected.

--- a/src/bin/dhcp4/tests/fqdn_unittest.cc
+++ b/src/bin/dhcp4/tests/fqdn_unittest.cc
@@ -427,7 +427,7 @@ public:
     // in a client request correctly, according to the replace-client-name
     // mode configuration parameter.
     //
-    // @param mode - value to use client-name-replacment parameter - for
+    // @param mode - value to use client-name-replacement parameter - for
     // mode labels such as NEVER and ALWAYS must incluce enclosing quotes:
     // "\"NEVER\"".  This allows us to also pass in boolean literals which
     // are unquoted.
@@ -568,7 +568,7 @@ public:
     /// @param len - expected lease length in the NCR
     /// @param not_strict_expire_check - when true the comparison of the NCR
     /// lease expiration time is conducted as greater than or equal to rather
-    /// equal to CLTT plus lease lenght.
+    /// equal to CLTT plus lease length.
     void verifyNameChangeRequest(const isc::dhcp_ddns::NameChangeType type,
                                  const bool reverse, const bool forward,
                                  const std::string& addr,
@@ -1462,7 +1462,7 @@ TEST_F(NameDhcpv4SrvTest, hostnameReservationNoDNSQualifyingSuffix) {
 // Test verifies that the server properly generates a FQDN when the client
 // FQDN name is blank, whether or not DDNS updates are enabled.  It also
 // verifies that the lease is only in the database following a DHCPREQUEST and
-// that the lesae contains the generated FQDN.
+// that the lease contains the generated FQDN.
 TEST_F(NameDhcpv4SrvTest, emptyFqdn) {
     Dhcp4Client client(Dhcp4Client::SELECTING);
     isc::asiolink::IOAddress expected_address("10.0.0.10");

--- a/src/bin/dhcp4/tests/host_options_unittest.cc
+++ b/src/bin/dhcp4/tests/host_options_unittest.cc
@@ -81,9 +81,9 @@ const bool STATEFUL = false;
 ///   - Single subnet 10.0.0.0/24 with a pool of 10.0.0.10-10.0.0.100
 ///   - Single reservation within the subnet:
 ///     - HW address: aa:bb:cc:dd:ee:ff
-///     - ip-adress 10.0.0.7
+///     - ip-address 10.0.0.7
 ///     - Vendor option for Cable Labs vendor id specified for the reservation:
-///       - TFTP servers suboption overriding globally spececified suboption:
+///       - TFTP servers suboption overriding globally specified suboption:
 ///         10.1.1.202,10.1.1.203
 ///
 const char* HOST_CONFIGS[] = {
@@ -252,7 +252,7 @@ public:
     /// Overridden options are requested with Parameter Request List
     /// option.
     ///
-    /// @param stateless Boolean value indicating if statless or stateful
+    /// @param stateless Boolean value indicating if stateless or stateful
     /// configuration should be performed.
     void testOverrideRequestedOptions(const bool stateless);
 
@@ -262,21 +262,21 @@ public:
     /// Overridden options are the options which server sends regardless
     /// if they are requested with Parameter Request List option or not.
     ///
-    /// @param stateless Boolean value indicating if statless or stateful
+    /// @param stateless Boolean value indicating if stateless or stateful
     /// configuration should be performed.
     void testOverrideDefaultOptions(const bool stateless);
 
     /// @brief Verifies that client receives options when they are solely
     /// defined in the host scope (and not in the global or subnet scope).
     ///
-    /// @param stateless Boolean value indicating if statless or stateful
+    /// @param stateless Boolean value indicating if stateless or stateful
     /// configuration should be performed.
     void testHostOnlyOptions(const bool stateless);
 
     /// @brief Verifies that host specific vendor options override vendor
     /// options defined in the global scope.
     ///
-    /// @param stateless Boolean value indicating if statless or stateful
+    /// @param stateless Boolean value indicating if stateless or stateful
     /// configuration should be performed.
     void testOverrideVendorOptions(const bool stateless);
 

--- a/src/bin/dhcp4/tests/inform_unittest.cc
+++ b/src/bin/dhcp4/tests/inform_unittest.cc
@@ -139,7 +139,7 @@ public:
         isc::stats::StatsMgr::instance().removeAll();
     }
 
-    /// @brief Desctructor.
+    /// @brief Destructor.
     ///
     /// Cleans up statistics after the test.
     ~InformTest() {

--- a/src/bin/dhcp4/tests/kea_controller_unittest.cc
+++ b/src/bin/dhcp4/tests/kea_controller_unittest.cc
@@ -349,7 +349,7 @@ TEST_F(JSONFileBackendTest, timers) {
         "}";
     writeFile(config);
 
-    // Create an instance of the server and intialize it.
+    // Create an instance of the server and initialize it.
     boost::scoped_ptr<ControlledDhcpv4Srv> srv;
     ASSERT_NO_THROW(srv.reset(new ControlledDhcpv4Srv(0)));
     ASSERT_NO_THROW(srv->init(TEST_FILE));
@@ -418,7 +418,7 @@ TEST_F(JSONFileBackendTest, defaultLeaseDbBackend) {
         "}";
     writeFile(config);
 
-    // Create an instance of the server and intialize it.
+    // Create an instance of the server and initialize it.
     boost::scoped_ptr<ControlledDhcpv4Srv> srv;
     ASSERT_NO_THROW(srv.reset(new ControlledDhcpv4Srv(0)));
     ASSERT_NO_THROW(srv->init(TEST_FILE));
@@ -520,7 +520,7 @@ testBackendReconfiguration(const std::string& backend_first,
                            const std::string& backend_second) {
     writeFile(createConfiguration(backend_first));
 
-    // Create an instance of the server and intialize it.
+    // Create an instance of the server and initialize it.
     boost::scoped_ptr<NakedControlledDhcpv4Srv> srv;
     ASSERT_NO_THROW(srv.reset(new NakedControlledDhcpv4Srv()));
     srv->setConfigFile(TEST_FILE);

--- a/src/bin/dhcp4/tests/marker_file.h.in
+++ b/src/bin/dhcp4/tests/marker_file.h.in
@@ -45,7 +45,7 @@ checkMarkerFile(const char* name, const char* expected);
 ///
 /// This function is used in some of the DHCP server tests.
 ///
-/// Checkes that the specified file does NOT exist.
+/// Checks that the specified file does NOT exist.
 ///
 /// @param name Name of the marker file.
 ///

--- a/src/bin/dhcp4/tests/out_of_range_unittest.cc
+++ b/src/bin/dhcp4/tests/out_of_range_unittest.cc
@@ -203,7 +203,7 @@ public:
         IfaceMgr::instance().openSockets4();
     }
 
-    /// @brief Desctructor.
+    /// @brief Destructor.
     ///
     /// Cleans up statistics after the test.
     ~OutOfRangeTest() {
@@ -224,7 +224,7 @@ public:
     /// off the queue.  Note the function expects there to be 1 and only
     /// 1 NCR queued.
     ///
-    /// @param type - NCR type exepcted, either CHG_ADD or CHG_REMOVE
+    /// @param type - NCR type expected, either CHG_ADD or CHG_REMOVE
     /// @param addr - string containing the ip address expected in the NCR
     void verifyNameChangeRequest(const isc::dhcp_ddns::NameChangeType type,
                                  const std::string& addr) {
@@ -245,7 +245,7 @@ public:
     ///
     /// Each test cycles consists of a the following two stages, the first is
     /// a set-up stage during which the server is configured with an initial,
-    /// reference, configuration and a client then verifies that it can aquire
+    /// reference, configuration and a client then verifies that it can acquire
     /// and renew a lease.  The second stage verifies that the server, having
     /// been reconfigured such that the original lease is now "out-of-range",
     /// responds correctly to the same client first attempting to renew the
@@ -301,7 +301,7 @@ OutOfRangeTest::oorRenewReleaseTest(enum CfgIndex cfg_idx,
         client.setHWAddress(hwaddress);
     }
 
-    // Aquire the lease via DORA
+    // Acquire the lease via DORA
     ASSERT_NO_THROW(client.doDORA());
 
     // Make sure that the server responded.
@@ -406,7 +406,7 @@ TEST_F(OutOfRangeTest, dynamicOutOfSubnet) {
                         DOES_NOT_RENEW);
 }
 
-// Test verifies that once-valid dynamic address host reserveration,
+// Test verifies that once-valid dynamic address host reservation,
 // whose address is no longer within the subnet's pool:
 //
 // a: Is NAKed upon a renewal attempt
@@ -419,7 +419,7 @@ TEST_F(OutOfRangeTest, dynamicHostOutOfPool) {
     oorRenewReleaseTest(DIFF_POOL, hwaddress, expected_address, DOES_NOT_RENEW);
 }
 
-// Test verifies that once-valid dynamic address host reserveration,
+// Test verifies that once-valid dynamic address host reservation,
 // whose address is no longer within any configured subnet:
 //
 // a: Is NAKed upon a renewal attempt
@@ -433,7 +433,7 @@ TEST_F(OutOfRangeTest, dynamicHostOutOfSubnet) {
                         DOES_NOT_RENEW);
 }
 
-// Test verifies that once-valid dynamic address host reserveration,
+// Test verifies that once-valid dynamic address host reservation,
 // whose address is within the configured subnet and pool, but whose
 // reservation has been removed:
 //
@@ -449,7 +449,7 @@ TEST_F(OutOfRangeTest, dynamicHostReservationRemoved) {
     oorRenewReleaseTest(NO_HR, hwaddress, expected_address, DOES_RENEW);
 }
 
-// Test verifies that once-valid dynamic address host reserveration,
+// Test verifies that once-valid dynamic address host reservation,
 // whose address is no longer within any configured subnet, and which
 // no longer has reservation defined:
 //
@@ -466,7 +466,7 @@ TEST_F(OutOfRangeTest, dynamicHostOutOfSubnetReservationRemoved) {
                         DOES_NOT_RENEW);
 }
 
-// Test verifies that once-valid in-subnet fixed-address host reserveration,
+// Test verifies that once-valid in-subnet fixed-address host reservation,
 // after the subnet pool changes:
 //
 // a: Is NAK'd upon a renewal attempt
@@ -481,7 +481,7 @@ TEST_F(OutOfRangeTest, fixedHostOutOfSubnet) {
 }
 
 
-// Test verifies that once-valid in-subnet fixed-address host reserveration,
+// Test verifies that once-valid in-subnet fixed-address host reservation,
 // after the subnet pool is changed:
 //
 // a: Is ACK'd upon a renewal attempt
@@ -494,7 +494,7 @@ TEST_F(OutOfRangeTest, fixedHostDifferentPool) {
     oorRenewReleaseTest(DIFF_POOL, hwaddress, expected_address, DOES_RENEW);
 }
 
-// Test verifies that once-valid in-subnet fixed-address host reserveration,
+// Test verifies that once-valid in-subnet fixed-address host reservation,
 // whose reservation has been removed from the configuration
 //
 // a: Is NAK'd upon a renewal attempt
@@ -507,7 +507,7 @@ TEST_F(OutOfRangeTest, fixedHostReservationRemoved) {
     oorRenewReleaseTest(NO_HR, hwaddress, expected_address, DOES_NOT_RENEW);
 }
 
-// Test verifies that once-valid fixed address host reserveration,
+// Test verifies that once-valid fixed address host reservation,
 // whose address is no longer within any configured subnet
 //
 // a: Is NAKed upon a renewal attempt

--- a/src/bin/dhcp4/tests/release_unittest.cc
+++ b/src/bin/dhcp4/tests/release_unittest.cc
@@ -171,7 +171,7 @@ ReleaseTest::acquireAndRelease(const std::string& hw_address_1,
     if (expected_result == SHOULD_PASS) {
         EXPECT_FALSE(lease);
 
-        // The removal succeded, so the assigned-addresses statistic should
+        // The removal succeeded, so the assigned-addresses statistic should
         // be decreased by one
         EXPECT_EQ(before, after + 1);
     } else {

--- a/src/bin/dhcp6/ctrl_dhcp6_srv.h
+++ b/src/bin/dhcp6/ctrl_dhcp6_srv.h
@@ -167,7 +167,7 @@ private:
     /// this method.
     ///
     /// @param max_leases Maximum number of leases to be reclaimed.
-    /// @param timeout Maximum amount of time that the reclaimation routine
+    /// @param timeout Maximum amount of time that the reclamation routine
     /// may be processing expired leases, expressed in milliseconds.
     /// @param remove_lease A boolean value indicating if the lease should
     /// be removed when it is reclaimed (if true) or it should be left in the

--- a/src/bin/dhcp6/dhcp6_srv.cc
+++ b/src/bin/dhcp6/dhcp6_srv.cc
@@ -1646,7 +1646,7 @@ Dhcpv6Srv::extendIA_NA(const Pkt6Ptr& query, const Pkt6Ptr& answer,
     ia_rsp->setT1(subnet->getT1());
     ia_rsp->setT2(subnet->getT2());
 
-    // Get DDNS udpate directions
+    // Get DDNS update directions
     bool do_fwd = false;
     bool do_rev = false;
     Option6ClientFqdnPtr fqdn = boost::dynamic_pointer_cast<
@@ -1753,7 +1753,7 @@ Dhcpv6Srv::extendIA_NA(const Pkt6Ptr& query, const Pkt6Ptr& answer,
     // All is left is to insert the status code.
     if (leases.empty()) {
 
-        // The server wasn't able allocate new lease and renew an exising
+        // The server wasn't able allocate new lease and renew an existing
         // lease. In that case, the server sends NoAddrsAvail per RFC7550.
         ia_rsp->addOption(createStatusCode(*query, *ia_rsp,
                                            STATUS_NoAddrsAvail,
@@ -1916,7 +1916,7 @@ Dhcpv6Srv::extendIA_PD(const Pkt6Ptr& query,
     // All is left is to insert the status code.
     if (leases.empty()) {
 
-        // The server wasn't able allocate new lease and renew an exising
+        // The server wasn't able allocate new lease and renew an existing
         // lease. In that case, the server sends NoPrefixAvail per RFC7550.
         ia_rsp->addOption(createStatusCode(*query, *ia_rsp,
                                            STATUS_NoPrefixAvail,
@@ -2903,7 +2903,7 @@ Dhcpv6Srv::processInfRequest(const Pkt6Ptr& inf_request) {
     // Try to assign options that were requested by the client.
     appendRequestedOptions(inf_request, reply, co_list);
 
-    // Try to assigne vendor options that were requested by the client.
+    // Try to assign vendor options that were requested by the client.
     appendRequestedVendorOptions(inf_request, reply, ctx, co_list);
 
     return (reply);

--- a/src/bin/dhcp6/dhcp6_srv.h
+++ b/src/bin/dhcp6/dhcp6_srv.h
@@ -82,7 +82,7 @@ public:
     /// redeclaration/redefinition. @ref Daemon::getVersion()
     static std::string getVersion(bool extended);
 
-    /// @brief Returns server-indentifier option.
+    /// @brief Returns server-identifier option.
     ///
     /// @return server-id option
     OptionPtr getServerID() { return serverid_; }
@@ -692,7 +692,7 @@ protected:
     /// This method iterates over all IA_NA options and calls @ref declineIA on
     /// each of them.
     ///
-    /// @param decline Decline messege sent by a client
+    /// @param decline Decline message sent by a client
     /// @param reply Server's response (IA_NA with status will be added here)
     /// @param ctx context
     /// @return true when expected to continue, false when hooks told us to drop
@@ -722,7 +722,7 @@ protected:
     /// - cleans up DNS, if necessary
     /// - updates subnet[X].declined-addresses (per subnet stat)
     /// - updates declined-addresses (global stat)
-    /// - deassociates client information from the lease
+    /// - dissociates client information from the lease
     /// - moves the lease to DECLINED state
     /// - sets lease expiration time to decline-probation-period
     /// - adds status-code success

--- a/src/bin/dhcp6/json_config_parser.cc
+++ b/src/bin/dhcp6/json_config_parser.cc
@@ -832,7 +832,7 @@ configureDhcp6Server(Dhcpv6Srv&, isc::data::ConstElementPtr config_set) {
     // rollback informs whether error occurred and original data
     // have to be restored to global storages.
     bool rollback = false;
-    // config_pair holds ther details of the current parser when iterating over
+    // config_pair holds the details of the current parser when iterating over
     // the parsers.  It is declared outside the loop so in case of error, the
     // name of the failing parser can be retrieved within the "catch" clause.
     ConfigPair config_pair;

--- a/src/bin/dhcp6/main.cc
+++ b/src/bin/dhcp6/main.cc
@@ -158,8 +158,9 @@ main(int argc, char* argv[]) {
                 log_manager.process();
                 LOG_ERROR(dhcp6_logger, DHCP6_INIT_FAIL).arg(ex.what());
             } catch (...) {
-                // The exeption thrown during the initialization could originate
-                // from logger subsystem. Therefore LOG_ERROR() may fail as well.
+                // The exception thrown during the initialization could
+                // originate from logger subsystem. Therefore LOG_ERROR() may
+                // fail as well.
                 cerr << "Failed to initialize server: " << ex.what() << endl;
             }
 

--- a/src/bin/dhcp6/tests/config_parser_unittest.cc
+++ b/src/bin/dhcp6/tests/config_parser_unittest.cc
@@ -562,7 +562,7 @@ public:
         CfgMgr::instance().clear();
     }
 
-    /// @brief Test invalid option paramater value.
+    /// @brief Test invalid option parameter value.
     ///
     /// This test function constructs the simple configuration
     /// string and injects invalid option configuration into it.
@@ -776,7 +776,7 @@ TEST_F(Dhcp6ParserTest, emptySubnet) {
 
     ConstElementPtr status;
     EXPECT_NO_THROW(status = configureDhcp6Server(srv_, json));
-                    
+
     // returned value should be 0 (success)
     checkResult(status, 0);
 }
@@ -3785,7 +3785,7 @@ TEST_F(Dhcp6ParserTest, classifySubnets) {
 // This test checks the ability of the server to parse a configuration
 // containing a full, valid dhcp-ddns (D2ClientConfig) entry.
 TEST_F(Dhcp6ParserTest, d2ClientConfig) {
-    // Verify that the D2 configuraiton can be fetched and is set to disabled.
+    // Verify that the D2 configuration can be fetched and is set to disabled.
     D2ClientConfigPtr d2_client_config = CfgMgr::instance().getD2ClientConfig();
     EXPECT_FALSE(d2_client_config->getEnableUpdates());
 
@@ -3891,7 +3891,7 @@ TEST_F(Dhcp6ParserTest, invalidD2ClientConfig) {
     checkResult(status, 1);
     EXPECT_TRUE(errorContainsPosition(status, "<string>"));
 
-    // Verify that the D2 configuraiton can be fetched and is set to disabled.
+    // Verify that the D2 configuration can be fetched and is set to disabled.
     D2ClientConfigPtr d2_client_config = CfgMgr::instance().getD2ClientConfig();
     EXPECT_FALSE(d2_client_config->getEnableUpdates());
 

--- a/src/bin/dhcp6/tests/confirm_unittest.cc
+++ b/src/bin/dhcp6/tests/confirm_unittest.cc
@@ -274,7 +274,7 @@ TEST_F(ConfirmTest, relayedClientNoSubnet) {
     // Send Confirm message to the server.
     ASSERT_NO_THROW(client.doConfirm());
     // Client should have received a status code option and this option should
-    // indicate that the client is NotOnLink becuase subnet could not be
+    // indicate that the client is NotOnLink because subnet could not be
     // selected.
     ASSERT_TRUE(client.receivedStatusCode());
     ASSERT_EQ(STATUS_NotOnLink, client.getStatusCode());

--- a/src/bin/dhcp6/tests/decline_unittest.cc
+++ b/src/bin/dhcp6/tests/decline_unittest.cc
@@ -166,7 +166,7 @@ Dhcpv6SrvTest::acquireAndDecline(Dhcp6Client& client,
     if (expected_result == SHOULD_PASS) {
         EXPECT_EQ(Lease::STATE_DECLINED, lease->state_);
 
-        // The decline succeded, so the declined-addresses statistic should
+        // The decline succeeded, so the declined-addresses statistic should
         // be increased by one
         EXPECT_EQ(after, before + 1);
         EXPECT_EQ(after_global, before_global + 1);

--- a/src/bin/dhcp6/tests/dhcp6_test_utils.cc
+++ b/src/bin/dhcp6/tests/dhcp6_test_utils.cc
@@ -675,7 +675,7 @@ Dhcpv6SrvTest::testReceiveStats(uint8_t pkt_type, const std::string& stat_name) 
     // fakeReceive()
     srv.run();
 
-    // All expected statstics must be present.
+    // All expected statistics must be present.
     pkt6_rcvd = mgr.getObservation("pkt6-received");
     tested_stat = mgr.getObservation(stat_name);
     ASSERT_TRUE(pkt6_rcvd);

--- a/src/bin/dhcp6/tests/dhcp6_test_utils.h
+++ b/src/bin/dhcp6/tests/dhcp6_test_utils.h
@@ -376,7 +376,7 @@ public:
 // dependencies, we use forward declaration here.
 class Dhcp6Client;
 
-// Provides suport for tests against a preconfigured subnet6
+// Provides support for tests against a preconfigured subnet6
 // extends upon NakedDhcp6SrvTest
 class Dhcpv6SrvTest : public NakedDhcpv6SrvTest {
 public:

--- a/src/bin/dhcp6/tests/fqdn_unittest.cc
+++ b/src/bin/dhcp6/tests/fqdn_unittest.cc
@@ -234,7 +234,7 @@ public:
 
     /// @brief Adds IA option to the message.
     ///
-    /// Addded option holds an address.
+    /// Added option holds an address.
     ///
     /// @param iaid IAID
     /// @param pkt A DHCPv6 message to which the IA option should be added.
@@ -391,7 +391,7 @@ public:
     // in a client request correctly, according to the replace-client-name
     // mode configuration parameter.
     //
-    // @param mode - value to use client-name-replacment parameter - for
+    // @param mode - value to use client-name-replacement parameter - for
     // mode labels such as NEVER and ALWAYS must incluce enclosing quotes:
     // "\"NEVER\"".  This allows us to also pass in boolean literals which
     // are unquoted.
@@ -556,7 +556,7 @@ public:
     ///
     /// @param type An expected type of the NameChangeRequest (Add or Remove).
     /// @param reverse An expected setting of the reverse update flag.
-    /// @param forward An expected setting of the forward udpate flag.
+    /// @param forward An expected setting of the forward update flag.
     /// @param addr A string representation of the IPv6 address held in the
     /// NameChangeRequest.
     /// @param dhcid An expected DHCID value.
@@ -564,7 +564,7 @@ public:
     /// dhcp_ddns::D2Dhcid::createDigest() with the appropriate arguments. This
     /// method uses encryption tools to produce the value which cannot be
     /// easily duplicated by hand.  It is more or less necessary to generate
-    /// these values programmatically and place them here. Should the
+    /// these values programatically and place them here. Should the
     /// underlying implementation of createDigest() change these test values
     /// will likely need to be updated as well.
     /// @param expires A timestamp when the lease associated with the
@@ -793,7 +793,7 @@ TEST_F(FqdnDhcpv6SrvTest, createNameChangeRequests) {
 // Checks that NameChangeRequests to add entries are not
 // created when ddns updates are disabled.
 TEST_F(FqdnDhcpv6SrvTest, noAddRequestsWhenDisabled) {
-    // Disable DDNS udpates.
+    // Disable DDNS updates.
     disableD2();
 
     // Create Reply message with Client Id and Server id.

--- a/src/bin/dhcp6/tests/host_unittest.cc
+++ b/src/bin/dhcp6/tests/host_unittest.cc
@@ -532,7 +532,7 @@ public:
     void testLeaseForIA(const Reservation& r, size_t& address_count,
                         size_t& prefix_count);
 
-    /// @brief Checks if the client obtined lease for specified hint.
+    /// @brief Checks if the client obtained lease for specified hint.
     ///
     /// The hint belongs to a specific IA (identified by IAID) and is expected
     /// to be returned in this IA by the server.
@@ -1559,7 +1559,7 @@ TEST_F(HostTest, appendReservationDuringRenew) {
     EXPECT_TRUE(client_.hasLeaseForPrefix(IOAddress("3000:1:2::"), 64));
     EXPECT_TRUE(client_.hasLeaseForPrefix(IOAddress("3000:1:3::"), 64));
 
-    // Make sure that the replaced leases have been returned with zero liftimes.
+    // Make sure that the replaced leases have been returned with zero lifetimes.
     EXPECT_TRUE(client_.hasLeaseWithZeroLifetimeForAddress(dynamic_address_lease));
     EXPECT_TRUE(client_.hasLeaseWithZeroLifetimeForPrefix(dynamic_prefix_lease, 64));
 
@@ -1578,7 +1578,7 @@ TEST_F(HostTest, appendReservationDuringRenew) {
     // allocated once, i.e. 6 + 6 = 12.
     ASSERT_EQ(12, client_.getLeaseNum());
 
-    // All removed leases should be returned with zero liftimes.
+    // All removed leases should be returned with zero lifetimes.
     EXPECT_TRUE(client_.hasLeaseWithZeroLifetimeForAddress(IOAddress("2001:db8:1:1::1")));
     EXPECT_TRUE(client_.hasLeaseWithZeroLifetimeForAddress(IOAddress("2001:db8:1:1::2")));
     EXPECT_TRUE(client_.hasLeaseWithZeroLifetimeForAddress(IOAddress("2001:db8:1:1::3")));
@@ -1670,7 +1670,7 @@ TEST_F(HostTest, insertReservationDuringRenew) {
     EXPECT_TRUE(client_.hasLeaseForPrefix(IOAddress("3000:1:3::"), 64,
                                           IAID(6)));
 
-    // Make sure that the replaced leases have been returned with zero liftimes.
+    // Make sure that the replaced leases have been returned with zero lifetimes.
     EXPECT_TRUE(client_.hasLeaseWithZeroLifetimeForAddress(dynamic_address_lease));
     EXPECT_TRUE(client_.hasLeaseWithZeroLifetimeForPrefix(dynamic_prefix_lease, 64));
 }
@@ -1737,7 +1737,7 @@ TEST_F(HostTest, multipleIAsConflict) {
     ASSERT_TRUE(client_.hasLeaseForAddress(IOAddress("2001:db8:1::2"),
                                            IAID(1)));
     // The address "2001:db8:1::1" was hijacked by another client so it
-    // must not be assigned to thsi client.
+    // must not be assigned to this client.
     ASSERT_FALSE(client_.hasLeaseForAddress(IOAddress("2001:db8:1::1")));
     // This client should have got an address from the dynamic pool excluding
     // two addresses already assigned, i.e. excluding "2001:db8:1::1" and

--- a/src/bin/dhcp6/tests/infrequest_unittest.cc
+++ b/src/bin/dhcp6/tests/infrequest_unittest.cc
@@ -24,7 +24,7 @@ namespace {
 ///   - one subnet used on eth0 interface
 ///     - with address and prefix pools
 ///     - dns-servers option
-/// - Configuation 1:
+/// - Configuration 1:
 ///   - one subnet used on eth0 interface
 ///     - no addresses or prefixes
 ///     - domain-search option

--- a/src/bin/dhcp6/tests/kea_controller_unittest.cc
+++ b/src/bin/dhcp6/tests/kea_controller_unittest.cc
@@ -485,7 +485,7 @@ TEST_F(JSONFileBackendTest, timers) {
         "}";
     writeFile(TEST_FILE, config);
 
-    // Create an instance of the server and intialize it.
+    // Create an instance of the server and initialize it.
     boost::scoped_ptr<ControlledDhcpv6Srv> srv;
     ASSERT_NO_THROW(srv.reset(new ControlledDhcpv6Srv(0)));
     ASSERT_NO_THROW(srv->init(TEST_FILE));
@@ -562,7 +562,7 @@ TEST_F(JSONFileBackendTest, serverId) {
         "}";
     writeFile(TEST_FILE, config);
 
-    // Create an instance of the server and intialize it.
+    // Create an instance of the server and initialize it.
     boost::scoped_ptr<ControlledDhcpv6Srv> srv;
     ASSERT_NO_THROW(srv.reset(new ControlledDhcpv6Srv(0)));
     ASSERT_NO_THROW(srv->init(TEST_FILE));
@@ -593,7 +593,7 @@ TEST_F(JSONFileBackendTest, defaultLeaseDbBackend) {
         "}";
     writeFile(TEST_FILE, config);
 
-    // Create an instance of the server and intialize it.
+    // Create an instance of the server and initialize it.
     boost::scoped_ptr<ControlledDhcpv6Srv> srv;
     ASSERT_NO_THROW(srv.reset(new ControlledDhcpv6Srv(0)));
     ASSERT_NO_THROW(srv->init(TEST_FILE));
@@ -696,7 +696,7 @@ testBackendReconfiguration(const std::string& backend_first,
                            const std::string& backend_second) {
     writeFile(TEST_FILE, createConfiguration(backend_first));
 
-    // Create an instance of the server and intialize it.
+    // Create an instance of the server and initialize it.
     boost::scoped_ptr<NakedControlledDhcpv6Srv> srv;
     ASSERT_NO_THROW(srv.reset(new NakedControlledDhcpv6Srv()));
     srv->setConfigFile(TEST_FILE);

--- a/src/bin/dhcp6/tests/marker_file.h.in
+++ b/src/bin/dhcp6/tests/marker_file.h.in
@@ -45,7 +45,7 @@ checkMarkerFile(const char* name, const char* expected);
 ///
 /// This function is used in some of the DHCP server tests.
 ///
-/// Checkes that the specified file does NOT exist.
+/// Checks that the specified file does NOT exist.
 ///
 /// @param name Name of the marker file.
 ///

--- a/src/bin/dhcp6/tests/sarr_unittest.cc
+++ b/src/bin/dhcp6/tests/sarr_unittest.cc
@@ -513,7 +513,7 @@ TEST_F(SARRTest, sarrStats) {
     // Server should have assigned a prefix.
     ASSERT_EQ(1, client.getLeaseNum());
 
-    // All expected statstics must be present now.
+    // All expected statistics must be present now.
     pkt6_rcvd = mgr.getObservation("pkt6-received");
     pkt6_solicit_rcvd = mgr.getObservation("pkt6-solicit-received");
     pkt6_adv_sent = mgr.getObservation("pkt6-advertise-sent");

--- a/src/bin/keactrl/keactrl.in
+++ b/src/bin/keactrl/keactrl.in
@@ -57,7 +57,7 @@ usage() {
 }
 
 ### Functions managing Kea processes ###
-# Contructs a server's PID file based on its binary name, the config file,
+# Constructs a server's PID file based on its binary name, the config file,
 # and the --localstatedir and returns the contents as $_pid.   If the file
 # does not exist, the value of $_pid is 0.  If the file exists but cannot
 # be read the function exists with a error message. Note the PID file name

--- a/src/bin/lfc/lfc_controller.cc
+++ b/src/bin/lfc/lfc_controller.cc
@@ -311,7 +311,7 @@ LFCController::usage(const std::string& text) {
               << "   -f <file>: finish file" << std::endl
               << "   -c <file>: configuration file" << std::endl
               << "   -v: print version number and exit" << std::endl
-              << "   -V: print extended version inforamtion and exit" << std::endl
+              << "   -V: print extended version information and exit" << std::endl
               << "   -d: optional, verbose output " << std::endl
               << "   -h: print this message " << std::endl
               << std::endl;

--- a/src/bin/lfc/lfc_controller.h
+++ b/src/bin/lfc/lfc_controller.h
@@ -154,7 +154,7 @@ public:
 private:
     /// Version of the DHCP protocol used, i.e. 4 or 6.
     int protocol_version_;
-    /// When true output the result of parsing the comamnd line
+    /// When true output the result of parsing the command line
     bool verbose_;
     std::string config_file_;   ///< The path to the config file
     std::string previous_file_; ///< The path to the previous LFC file (if any)

--- a/src/bin/lfc/tests/lfc_controller_unittests.cc
+++ b/src/bin/lfc/tests/lfc_controller_unittests.cc
@@ -219,7 +219,7 @@ TEST_F(LFCControllerTest, notEnoughData) {
 /// @brief Verify that extra arguments cause the parse to fail.
 /// Parse a full command line plus some extra arguments on the end
 /// to verify that we don't stop parsing when we find all of the
-/// required arguments.  We exepct the parse to fail with an
+/// required arguments.  We expect the parse to fail with an
 /// InvalidUsage exception.
 TEST_F(LFCControllerTest, tooMuchData) {
     LFCController lfc_controller;
@@ -297,7 +297,7 @@ TEST_F(LFCControllerTest, fileRotate) {
     int argc = 14;
     lfc_controller.parseArgs(argc, argv);
 
-    // Test 1: Start with no files - we expect an execption as there
+    // Test 1: Start with no files - we expect an exception as there
     // is no file to copy.
     EXPECT_THROW(lfc_controller.fileRotate(), RunTimeFail);
     removeTestFile();

--- a/src/bin/perfdhcp/command_options.cc
+++ b/src/bin/perfdhcp/command_options.cc
@@ -230,7 +230,7 @@ CommandOptions::initialize(int argc, char** argv, bool print_cmd_line) {
             // agent. In the future we should extend it to up to 32.
             // See comment in https://github.com/isc-projects/kea/pull/22#issuecomment-243405600
             v6_relay_encapsulation_level_ =
-                static_cast<uint8_t>(positiveInteger("-A<encapusulation-level> must"
+                static_cast<uint8_t>(positiveInteger("-A<encapsulation-level> must"
                                                      " be a positive integer"));
             if (v6_relay_encapsulation_level_ != 1) {
                 isc_throw(isc::InvalidParameter, "-A only supports 1 at the moment.");
@@ -972,7 +972,7 @@ CommandOptions::printCommandLine() const {
 void
 CommandOptions::usage() const {
     std::cout <<
-        "perfdhcp [-hv] [-4|-6] [-A<encapusulation-level>] [-e<lease-type>]"
+        "perfdhcp [-hv] [-4|-6] [-A<encapsulation-level>] [-e<lease-type>]"
         "         [-r<rate>] [-f<renew-rate>]\n"
         "         [-F<release-rate>] [-t<report>] [-R<range>] [-b<base>]\n"
         "         [-n<num-request>] [-p<test-period>] [-d<drop-time>]\n"
@@ -1086,7 +1086,7 @@ CommandOptions::usage() const {
         "    the exchange rate (given by -r<rate>).  Furthermore the sum of\n"
         "    this value and the renew-rate (given by -f<rate) must be equal\n"
         "    to or less than the exchange rate.\n"
-        "-A<encapusulation-level>: Specifies that relayed traffic must be\n"
+        "-A<encapsulation-level>: Specifies that relayed traffic must be\n"
         "    generated. The argument specifies the level of encapsulation, i.e.\n"
         "    how many relay agents are simulated. Currently the only supported\n"
         "    <encapsulation-level> value is 1, which means that the generated\n"

--- a/src/bin/perfdhcp/perf_pkt6.h
+++ b/src/bin/perfdhcp/perf_pkt6.h
@@ -85,7 +85,7 @@ public:
     /// \brief Handles limited binary packet parsing for packets with
     /// custom offsets of options and transaction id
     ///
-    /// This methoid handles the parsing of packets that have custom offsets
+    /// This method handles the parsing of packets that have custom offsets
     /// of options or transaction ID. Use
     /// \ref isc::dhcp::Pkt4::addOption to specify which options to parse.
     /// Options should be of the \ref isc::perfdhcp::LocalizedOption

--- a/src/bin/perfdhcp/test_control.h
+++ b/src/bin/perfdhcp/test_control.h
@@ -660,7 +660,7 @@ protected:
     /// being sent to the server. It collects first packets of each
     /// type and keeps them around until test finishes. Then they
     /// are printed to the user. If packet of specified type has
-    /// been already stored this function perfroms no operation.
+    /// been already stored this function performs no operation.
     /// This function does not perform sanity check if packet
     /// pointer is valid. Make sure it is before calling it.
     ///
@@ -675,7 +675,7 @@ protected:
     /// being sent to the server. It collects first packets of each
     /// type and keeps them around until test finishes. Then they
     /// are printed to the user. If packet of specified type has
-    /// been already stored this function perfroms no operation.
+    /// been already stored this function performs no operation.
     /// This function does not perform sanity check if packet
     /// pointer is valid. Make sure it is before calling it.
     ///

--- a/src/bin/perfdhcp/tests/command_options_helper.h
+++ b/src/bin/perfdhcp/tests/command_options_helper.h
@@ -97,7 +97,7 @@ private:
 
     /// \brief Split string to the array of C-strings.
     ///
-    /// \param text_to_split string to be splited.
+    /// \param text_to_split string to be split.
     /// \param [out] num number of substrings returned.
     /// \param std::bad_alloc if allocation of C-strings failed.
     /// \return array of C-strings created from split.
@@ -108,7 +108,7 @@ private:
         // Iterators to be used for tokenization
         std::istream_iterator<std::string> text_iterator(text_stream);
         std::istream_iterator<std::string> text_end;
-        // Tokenize string (space is a separator) using begin and end iteratos
+        // Tokenize string (space is a separator) using begin and end iterators
         std::vector<std::string> tokens(text_iterator, text_end);
 
         if (!tokens.empty()) {

--- a/src/bin/perfdhcp/tests/perf_pkt4_unittest.cc
+++ b/src/bin/perfdhcp/tests/perf_pkt4_unittest.cc
@@ -344,7 +344,7 @@ TEST_F(PerfPkt4Test, PackTransactionId) {
 }
 
 TEST_F(PerfPkt4Test, UnpackTransactionId) {
-    // Initialize packet data, lebgth 268, zeros only.
+    // Initialize packet data, length 268, zeros only.
     std::vector<uint8_t> in_data(268, 0);
 
     // Assume that transaction id is at offset 100.
@@ -377,7 +377,7 @@ TEST_F(PerfPkt4Test, UnpackTransactionId) {
 }
 
 TEST_F(PerfPkt4Test, Writes) {
-    // Initialize intput buffer with 260 elements set to value 1.
+    // Initialize input buffer with 260 elements set to value 1.
     dhcp::OptionBuffer in_data(260, 1);
     // Initialize buffer to be used for write: 1,2,3,4,...,9
     dhcp::OptionBuffer write_buf(10);

--- a/src/bin/perfdhcp/tests/perf_pkt6_unittest.cc
+++ b/src/bin/perfdhcp/tests/perf_pkt6_unittest.cc
@@ -217,7 +217,7 @@ TEST_F(PerfPkt6Test, InvalidOptions) {
 
     // Create packet.
     boost::scoped_ptr<PerfPkt6> pkt2(capture());
-    // Testing offset of the option (lower than pakcet size but
+    // Testing offset of the option (lower than packet size but
     // tail of the option out of bounds).
     LocalizedOptionPtr pkt2_serverid(new LocalizedOption(Option::V6,
                                                          D6O_SERVERID,

--- a/src/bin/perfdhcp/tests/rate_control_unittest.cc
+++ b/src/bin/perfdhcp/tests/rate_control_unittest.cc
@@ -122,7 +122,7 @@ TEST(RateControl, isLateSent) {
 // depends on time.
 TEST(RateControl, getOutboundMessageCount) {
     // Test that the number of outbound messages is correctly defined by the
-    // rate.  The agressivity is set high enough so that it will not restrict
+    // rate.  The aggressivity is set high enough so that it will not restrict
     // the calculated count.
     NakedRateControl rc1(1000, 1000000);
     // Set the timestamp of the last sent message well to the past. The
@@ -135,7 +135,7 @@ TEST(RateControl, getOutboundMessageCount) {
     // The number of messages to be sent must be roughly equal to the time
     // between the last sent message and the current time multiplied by the
     // rate.  ("Roughly", as current time is advancing, so the actual interval
-    // when the calcuation is made may be different from the interval set.)  The
+    // when the measurement is made may be different from the interval set.) The
     // margin in this test is reasonably generous, allowing for a timing error
     // of around 10ms.
     uint64_t count = 0;
@@ -143,7 +143,7 @@ TEST(RateControl, getOutboundMessageCount) {
     EXPECT_TRUE((count >= 5240) && (count <= 5260)) <<
         "count is " << count << ", expected range 5240-5260";
 
-    // Check that the agressivity limits the count of messages.
+    // Check that the aggressivity limits the count of messages.
     NakedRateControl rc2(1000, 3500);
     rc2.last_sent_ =
         NakedRateControl::currentTime() - boost::posix_time::seconds(5) -

--- a/src/bin/perfdhcp/tests/test_control_unittest.cc
+++ b/src/bin/perfdhcp/tests/test_control_unittest.cc
@@ -32,7 +32,7 @@ using namespace isc::perfdhcp;
 
 /// \brief Test Control class with protected members made public.
 ///
-/// This class makes protected TestControl class'es member public
+/// This class makes protected TestControl class's members public
 /// to allow unit testing.
 class NakedTestControl: public TestControl {
 public:

--- a/src/bin/sockcreator/tests/sockcreator_tests.cc
+++ b/src/bin/sockcreator/tests/sockcreator_tests.cc
@@ -54,7 +54,7 @@ setAddressFamilyFields(sockaddr_in6* address) {
     address->sin6_addr = in6addr_loopback;
 }
 
-// Socket has been opened, peform a check on it.  The sole argument is the
+// Socket has been opened, perform a check on it.  The sole argument is the
 // socket descriptor.  The TCP check is the same regardless of the address
 // family.  The UDP check requires that the socket address be obtained so
 // is parameterised on the type of structure required to hold the address.
@@ -94,7 +94,7 @@ udpCheck(const int socknum) {
 // code, so provide a convenient typedef.
 typedef void (*socket_check_t)(const int);
 
-// Address-family-specific scoket checks.
+// Address-family-specific socket checks.
 //
 // The first argument is used to select the overloaded check function.
 // The other argument is the socket descriptor number.
@@ -306,7 +306,7 @@ getSockDummy(const int type, struct sockaddr* addr, const socklen_t,
 int
 send_FdDummy(const int destination, const int what) {
     // Make sure it is 1 byte so we know the length. We do not use more during
-    // the test anyway.  And even with the LS bute, we can distinguish between
+    // the test anyway.  And even with the LS byte, we can distinguish between
     // the different results.
     const char fd_data = what & 0xff;
     const bool status = write_data(destination, &fd_data, sizeof(fd_data));

--- a/src/hooks/dhcp/user_chk/pkt_send_co.cc
+++ b/src/hooks/dhcp/user_chk/pkt_send_co.cc
@@ -259,7 +259,7 @@ void add4Option(Pkt4Ptr& response, uint8_t opt_code, std::string& opt_value) {
 /// - DOCSIS3_V6_CONFIG_FILE from user property "bootfile"
 /// - DOCSIS3_V6_TFTP_SERVERS from user property "tftp_server"
 ///
-/// @param response IPv5 reponse packet
+/// @param response IPv5 response packet
 /// @param user User from whom properties are sourced
 void add6Options(Pkt6Ptr& response, const UserPtr& user) {
     if (!user) {

--- a/src/hooks/dhcp/user_chk/tests/user_file_unittests.cc
+++ b/src/hooks/dhcp/user_chk/tests/user_file_unittests.cc
@@ -41,11 +41,11 @@ TEST(UserFile, construction) {
 TEST(UserFile, openFile) {
     UserFilePtr user_file;
 
-    // Construct a user file that refers to a non existant file.
+    // Construct a user file that refers to a non existing file.
     ASSERT_NO_THROW(user_file.reset(new UserFile("NoSuchFile")));
     EXPECT_FALSE(user_file->isOpen());
 
-    // Verify a non-existant file fails to open
+    // Verify a non-existing file fails to open
     ASSERT_THROW(user_file->open(), UserFileError);
     EXPECT_FALSE(user_file->isOpen());
 
@@ -62,7 +62,7 @@ TEST(UserFile, openFile) {
     // Verify that we cannot open an already open file.
     ASSERT_THROW(user_file->open(), UserFileError);
 
-    // Verifyt we can close it.
+    // Verify we can close it.
     ASSERT_NO_THROW(user_file->close());
     EXPECT_FALSE(user_file->isOpen());
 
@@ -75,7 +75,7 @@ TEST(UserFile, openFile) {
 /// @brief Tests makeUser with invalid user strings
 TEST(UserFile, makeUser) {
     const char* invalid_strs[]= {
-        // Missinge type element.
+        // Missing type element.
         "{ \"id\" : \"01AC00F03344\" }",
         // Invalid id type string value.
         "{ \"type\" : \"BOGUS\", \"id\" : \"01AC00F03344\"}",

--- a/src/hooks/dhcp/user_chk/tests/user_registry_unittests.cc
+++ b/src/hooks/dhcp/user_chk/tests/user_registry_unittests.cc
@@ -61,7 +61,7 @@ TEST(UserRegistry, userBasics) {
     EXPECT_TRUE(found_user);
     EXPECT_EQ(found_user->getUserId(), *id);
 
-    // Verify that searching for a non-existant user returns empty user pointer.
+    // Verify that searching for a non-existing user returns empty user pointer.
     UserIdPtr id2;
     ASSERT_NO_THROW(id2.reset(new UserId(UserId::HW_ADDRESS, "02020202")));
     ASSERT_NO_THROW(found_user = reg->findUser(*id2));

--- a/src/hooks/dhcp/user_chk/tests/userid_unittests.cc
+++ b/src/hooks/dhcp/user_chk/tests/userid_unittests.cc
@@ -50,21 +50,21 @@ TEST(UserIdTest, hwAddress_type) {
     EXPECT_EQ(id->getType(), UserId::HW_ADDRESS);
     EXPECT_TRUE(bytes == id->getId());
 
-    // Check relational oeprators when a == b.
+    // Check relational operators when a == b.
     UserIdPtr id2;
     ASSERT_NO_THROW(id2.reset(new UserId(UserId::HW_ADDRESS, id->toText())));
     EXPECT_TRUE(*id == *id2);
     EXPECT_FALSE(*id != *id2);
     EXPECT_FALSE(*id < *id2);
 
-    // Check relational oeprators when a < b.
+    // Check relational operators when a < b.
     ASSERT_NO_THROW(id2.reset(new UserId(UserId::HW_ADDRESS,
                                          "01FF02AC030B0709")));
     EXPECT_FALSE(*id == *id2);
     EXPECT_TRUE(*id != *id2);
     EXPECT_TRUE(*id < *id2);
 
-    // Check relational oeprators when a > b.
+    // Check relational operators when a > b.
     ASSERT_NO_THROW(id2.reset(new UserId(UserId::HW_ADDRESS,
                                          "01FF02AC030B0707")));
     EXPECT_FALSE(*id == *id2);
@@ -98,20 +98,20 @@ TEST(UserIdTest, duid_type) {
     EXPECT_EQ(id->getType(), UserId::DUID);
     EXPECT_TRUE(bytes == id->getId());
 
-    // Check relational oeprators when a == b.
+    // Check relational operators when a == b.
     UserIdPtr id2;
     ASSERT_NO_THROW(id2.reset(new UserId(UserId::DUID, id->toText())));
     EXPECT_TRUE(*id == *id2);
     EXPECT_FALSE(*id != *id2);
     EXPECT_FALSE(*id < *id2);
 
-    // Check relational oeprators when a < b.
+    // Check relational operators when a < b.
     ASSERT_NO_THROW(id2.reset(new UserId(UserId::DUID, "01FF02AC030B0709")));
     EXPECT_FALSE(*id == *id2);
     EXPECT_TRUE(*id != *id2);
     EXPECT_TRUE(*id < *id2);
 
-    // Check relational oeprators when a > b.
+    // Check relational operators when a > b.
     ASSERT_NO_THROW(id2.reset(new UserId(UserId::DUID, "01FF02AC030B0707")));
     EXPECT_FALSE(*id == *id2);
     EXPECT_TRUE(*id != *id2);

--- a/src/hooks/dhcp/user_chk/user.cc
+++ b/src/hooks/dhcp/user_chk/user.cc
@@ -38,7 +38,7 @@ UserId::UserId(UserIdType id_type, const std::string & id_str) :
     // Input is expected to be 2-digits per bytes, no delimiters.
     std::vector<uint8_t> addr_bytes;
 
-    // Strip out colon delimeters, decodeHex doesn't like them.
+    // Strip out colon delimiters, decodeHex doesn't like them.
     std::string clean_id_str = id_str;
     std::string::iterator end_pos = std::remove(clean_id_str.begin(),
                                                 clean_id_str.end(), ':');

--- a/src/hooks/dhcp/user_chk/user_file.h
+++ b/src/hooks/dhcp/user_chk/user_file.h
@@ -43,7 +43,7 @@ public:
 ///
 /// Each entry must have a valid entry for "type" and a valid entry or "id".
 ///
-/// If an entry contains duplicate option names, that option will be assigend
+/// If an entry contains duplicate option names, that option will be assigned
 /// the last value found. This is typical JSON behavior.
 /// Currently, only string option values (i.e. enclosed in quotes) are
 /// supported.

--- a/src/hooks/dhcp/user_chk/user_registry.cc
+++ b/src/hooks/dhcp/user_chk/user_registry.cc
@@ -85,7 +85,7 @@ void UserRegistry::refresh() {
             addUser(user);
         }
     } catch (const std::exception& ex) {
-        // Source was compromsised so restore registry from backup.
+        // Source was compromised so restore registry from backup.
         users_ = backup;
         // Close the source.
         source_->close();

--- a/src/lib/asiodns/README
+++ b/src/lib/asiodns/README
@@ -9,7 +9,7 @@ routines to be written in a straightfowrard step-step-step fashion rather
 than as a complex chain of separate handler functions.
 
 Coroutine objects (i.e., UDPServer, TCPServer and IOFetch) are objects
-with reenterable operator() members.  When an instance of one of these
+with reentrant operator() members.  When an instance of one of these
 classes is called as a function, it resumes at the position where it left
 off.  Thus, a UDPServer can issue an asynchronous I/O call and specify
 itself as the handler object; when the call completes, the UDPServer
@@ -89,7 +89,7 @@ fetch logic:
            |
       IOAsioSocket
            |
-     +-----+-----+                
+     +-----+-----+
      |           |
 UDPSocket    TCPSocket
 
@@ -122,7 +122,7 @@ protocol to use.  The sequence is:
     if (! synchronous) {
         YIELD;
     }
-    YIELD asyncSend(query)           // Send query 
+    YIELD asyncSend(query)           // Send query
     do {
         YIELD asyncReceive(response) // Read response
     } while (! complete(response))

--- a/src/lib/asiolink/asio_wrapper.h
+++ b/src/lib/asiolink/asio_wrapper.h
@@ -34,8 +34,8 @@
 // causes two instances of error_code which should have been equal to
 // to not be equal.
 //
-// The problem disappers if either error handling code is not built header
-// only as this results in a single definiton of system_category() supplied
+// The problem disappears if either error handling code is not built header
+// only as this results in a single definition of system_category() supplied
 // by libboost_system; or the error handling code is not optimized.
 //
 // We're doing the test here, rather than in configure to guard against the

--- a/src/lib/asiolink/io_address.h
+++ b/src/lib/asiolink/io_address.h
@@ -67,11 +67,11 @@ public:
 
     /// @brief Constructor for ip::address_v4 object.
     ///
-    /// This constructor is intented to be used when constructing
+    /// This constructor is intended to be used when constructing
     /// IPv4 address out of uint32_t type. Passed value must be in
     /// network byte order
     ///
-    /// @param v4address IPv4 address represnted by uint32_t
+    /// @param v4address IPv4 address represented by uint32_t
     IOAddress(uint32_t v4address);
 
     /// \brief Convert the address to a string.
@@ -183,7 +183,7 @@ public:
     ///
     /// It is useful for comparing which address is bigger.
     /// Operations within one protocol family are obvious.
-    /// Comparisons between v4 and v6 will allways return v4
+    /// Comparisons between v4 and v6 will always return v4
     /// being smaller. This follows boost::boost::asio::ip implementation
     bool lessThan(const IOAddress& other) const {
         if (this->getFamily() == other.getFamily()) {

--- a/src/lib/asiolink/tests/tcp_socket_unittest.cc
+++ b/src/lib/asiolink/tests/tcp_socket_unittest.cc
@@ -62,7 +62,7 @@ public:
         NONE = 4        ///< "Not set" state
     };
 
-    /// \brief Minimim size of buffers
+    /// \brief Minimum size of buffers
     enum {
         MIN_SIZE = (64 * 1024 + 2)          ///< 64kB + two bytes for a count
     };
@@ -149,7 +149,7 @@ public:
         return (ptr_->expected_);
     }
 
-    /// \brief Get offset intodData
+    /// \brief Get offset into data
     size_t& offset() {
         return (ptr_->offset_);
     }
@@ -418,7 +418,7 @@ TEST(TCPSocket, sequenceTest) {
     // Run the callbacks. Several options are possible depending on how ASIO
     // is implemented and whether the message gets fragmented:
     //
-    // 1) The send handler may complete immediately, regardess of whether the
+    // 1) The send handler may complete immediately, regardless of whether the
     // data has been read by the client.  (This is the most likely.)
     // 2) The send handler may only run after all the data has been read by
     // the client. (This could happen if the client's TCP buffers were too

--- a/src/lib/cc/command_interpreter.h
+++ b/src/lib/cc/command_interpreter.h
@@ -73,7 +73,7 @@ isc::data::ConstElementPtr createAnswer(const int status_code,
 /// @brief Creates a standard config/command level answer message
 ///
 /// @param status_code The return code (0 for success)
-/// @param status textual represenation of the status (used mostly for errors)
+/// @param status textual representation of the status (used mostly for errors)
 /// @param arg The optional argument for the answer. This can be of
 ///        any Element type. May be NULL.
 /// @return Standard command/config answer message

--- a/src/lib/cc/data.cc
+++ b/src/lib/cc/data.cc
@@ -1066,7 +1066,7 @@ void Element::preprocess(std::istream& in, std::stringstream& out) {
             line = "";
         }
 
-        // getline() removes end line charaters. Unfortunately, we need
+        // getline() removes end line characters. Unfortunately, we need
         // it for getting the line numbers right (in case we report an
         // error.
         out << line;

--- a/src/lib/cc/data.h
+++ b/src/lib/cc/data.h
@@ -78,7 +78,7 @@ public:
     /// \endcode
     ///
     /// the position of the element "bar" is: line_ = 2; pos_ = 9, because
-    /// begining of the value "123" is at offset 9 from the beginning of
+    /// beginning of the value "123" is at offset 9 from the beginning of
     /// the second line, including whitespaces.
     ///
     /// Note that the @c Position structure is used as an argument to @c Element
@@ -505,7 +505,7 @@ public:
     //@{
     /// Creates an Element from the wire format in the given
     /// stringstream of the given length.
-    /// Since the wire format is JSON, thise is the same as
+    /// Since the wire format is JSON, this is the same as
     /// fromJSON, and could be removed.
     ///
     /// \param in The input stringstream.
@@ -514,7 +514,7 @@ public:
     static ElementPtr fromWire(std::stringstream& in, int length);
 
     /// Creates an Element from the wire format in the given string
-    /// Since the wire format is JSON, thise is the same as
+    /// Since the wire format is JSON, this is the same as
     /// fromJSON, and could be removed.
     ///
     /// \param s The input string

--- a/src/lib/cc/tests/data_file_unittests.cc
+++ b/src/lib/cc/tests/data_file_unittests.cc
@@ -22,7 +22,7 @@ public:
 
     /// @brief writes specified text to a file
     ///
-    /// That is an auxilliary funtion used in fileRead() tests.
+    /// That is an auxilliary function used in fileRead() tests.
     ///
     /// @param content text to be written to disk
     void writeFile(const std::string& content) {

--- a/src/lib/config/command_mgr.h
+++ b/src/lib/config/command_mgr.h
@@ -80,7 +80,7 @@ public:
     /// @return the only existing instance of the manager
     static CommandMgr& instance();
 
-    /// @brief Opens control socket with paramters specified in socket_info
+    /// @brief Opens control socket with parameters specified in socket_info
     ///
     /// Currently supported types are:
     /// - unix (required parameters: socket-type: unix, socket-name:/unix/path)
@@ -132,7 +132,7 @@ public:
 
     /// @brief Auxiliary method that removes all installed commands.
     ///
-    /// The only unwipeable method is list-commands, which is internally
+    /// The only unwipable method is list-commands, which is internally
     /// handled at all times.
     void deregisterAll();
 

--- a/src/lib/dhcp/docsis3_option_defs.h
+++ b/src/lib/dhcp/docsis3_option_defs.h
@@ -54,7 +54,7 @@ const OptionDefParams DOCSIS3_V6_DEFS[] = {
     { "device-id",      DOCSIS3_V6_DEVICE_ID, OPT_BINARY_TYPE, false, NO_RECORD_DEF, "" },
     { "time-offset",    DOCSIS3_V6_TIME_OFFSET, OPT_INT32_TYPE, false, NO_RECORD_DEF, "" },
     { "cmts-cm-mac",    DOCSIS3_V6_CMTS_CM_MAC, OPT_BINARY_TYPE, false, NO_RECORD_DEF, "" }
-    // @todo add definitions for all remaning options.
+    // @todo add definitions for all remaining options.
 };
 
 /// Number of option definitions defined.

--- a/src/lib/dhcp/iface_mgr.cc
+++ b/src/lib/dhcp/iface_mgr.cc
@@ -68,7 +68,7 @@ Iface::closeSockets() {
 
 void
 Iface::closeSockets(const uint16_t family) {
-    // Check that the correect 'family' value has been specified.
+    // Check that the correct 'family' value has been specified.
     // The possible values are AF_INET or AF_INET6. Note that, in
     // the current code they are used to differentiate that the
     // socket is used to transmit IPv4 or IPv6 traffic. However,
@@ -937,7 +937,7 @@ Pkt4Ptr IfaceMgr::receive4(uint32_t timeout_sec, uint32_t timeout_usec /* = 0 */
     } else if (result < 0) {
         // In most cases we would like to know whether select() returned
         // an error because of a signal being received  or for some other
-        // reasaon. This is because DHCP servers use signals to trigger
+        // reason. This is because DHCP servers use signals to trigger
         // certain actions, like reconfiguration or graceful shutdown.
         // By catching a dedicated exception the caller will know if the
         // error returned by the function is due to the reception of the
@@ -1047,7 +1047,7 @@ Pkt6Ptr IfaceMgr::receive6(uint32_t timeout_sec, uint32_t timeout_usec /* = 0 */
     } else if (result < 0) {
         // In most cases we would like to know whether select() returned
         // an error because of a signal being received  or for some other
-        // reasaon. This is because DHCP servers use signals to trigger
+        // reason. This is because DHCP servers use signals to trigger
         // certain actions, like reconfiguration or graceful shutdown.
         // By catching a dedicated exception the caller will know if the
         // error returned by the function is due to the reception of the
@@ -1161,7 +1161,7 @@ IfaceMgr::getSocket(isc::dhcp::Pkt4 const& pkt) {
     }
 
     const Iface::SocketCollection& socket_collection = iface->getSockets();
-    // A candidate being an end of the iterator marks that it is a begining of
+    // A candidate being an end of the iterator marks that it is a beginning of
     // the socket search and that the candidate needs to be set to the first
     // socket found.
     Iface::SocketCollection::const_iterator candidate = socket_collection.end();

--- a/src/lib/dhcp/iface_mgr.h
+++ b/src/lib/dhcp/iface_mgr.h
@@ -58,7 +58,7 @@ public:
         isc::Exception(file, line, what) { };
 };
 
-/// @brief IfaceMgr exception thrown thrown when error occured during
+/// @brief IfaceMgr exception thrown thrown when error occurred during
 /// reading data from socket.
 class SocketReadError : public Exception {
 public:
@@ -66,7 +66,7 @@ public:
         isc::Exception(file, line, what) { };
 };
 
-/// @brief IfaceMgr exception thrown thrown when error occured during
+/// @brief IfaceMgr exception thrown thrown when error occurred during
 /// sedning data through socket.
 class SocketWriteError : public Exception {
 public:
@@ -303,7 +303,7 @@ public:
     /// @brief Check if the interface has the specified address assigned.
     ///
     /// @param address Address to be checked.
-    /// @return true if address is assigned to the intefrace, false otherwise.
+    /// @return true if address is assigned to the interface, false otherwise.
     bool hasAddress(const isc::asiolink::IOAddress& address) const;
 
     /// @brief Adds an address to an interface.
@@ -438,7 +438,7 @@ protected:
     /// Network interface name.
     std::string name_;
 
-    /// Interface index (a value that uniquely indentifies an interface).
+    /// Interface index (a value that uniquely identifies an interface).
     int ifindex_;
 
     /// List of assigned addresses.
@@ -724,7 +724,7 @@ public:
     /// (in microseconds)
     ///
     /// @throw isc::BadValue if timeout_usec is greater than one million
-    /// @throw isc::dhcp::SocketReadError if error occured when receiving a
+    /// @throw isc::dhcp::SocketReadError if error occurred when receiving a
     /// packet.
     /// @throw isc::dhcp::SignalInterruptOnSelect when a call to select() is
     /// interrupted by a signal.
@@ -746,7 +746,7 @@ public:
     /// (in microseconds)
     ///
     /// @throw isc::BadValue if timeout_usec is greater than one million
-    /// @throw isc::dhcp::SocketReadError if error occured when receiving a
+    /// @throw isc::dhcp::SocketReadError if error occurred when receiving a
     /// packet.
     /// @throw isc::dhcp::SignalInterruptOnSelect when a call to select() is
     /// interrupted by a signal.
@@ -1010,7 +1010,7 @@ public:
     /// @throw PacketFilterChangeDenied if there are open IPv4 sockets.
     void setPacketFilter(const PktFilterPtr& packet_filter);
 
-    /// @brief Set packet filter object to handle sending and receving DHCPv6
+    /// @brief Set packet filter object to handle sending and receiving DHCPv6
     /// messages.
     ///
     /// Packet filter objects provide means for the @c IfaceMgr to open sockets
@@ -1043,7 +1043,7 @@ public:
     /// implementation that supports this feature on a particular OS.
     /// If there isn't, the PktFilterInet object will be set. If the
     /// argument is set to 'false', PktFilterInet object instance will
-    /// be set as the Packet Filter regrdaless of the OS type.
+    /// be set as the Packet Filter regardless of the OS type.
     ///
     /// @param direct_response_desired specifies whether the Packet Filter
     /// object being set should support direct traffic to the host

--- a/src/lib/dhcp/iface_mgr_error_handler.h
+++ b/src/lib/dhcp/iface_mgr_error_handler.h
@@ -23,7 +23,7 @@
 /// cases it is expected that the exception is thrown instead. A possible
 /// solution would be to enclose this conditional behavior in a function.
 /// However, despite the hate for macros, the macro seems to be a bit
-/// better solution in this case as it allows to convenietly pass an
+/// better solution in this case as it allows to conveniently pass an
 /// error string in a stream (not as a string).
 ///
 /// @param ex_type Exception to be thrown if error_handler is NULL.

--- a/src/lib/dhcp/libdhcp++.h
+++ b/src/lib/dhcp/libdhcp++.h
@@ -298,7 +298,7 @@ public:
     /// @brief Removes runtime option definitions.
     static void clearRuntimeOptionDefs();
 
-    /// @brief Reverts uncommited changes to runtime option definitions.
+    /// @brief Reverts uncommitted changes to runtime option definitions.
     static void revertRuntimeOptionDefs();
 
     /// @brief Commits runtime option definitions.
@@ -368,7 +368,7 @@ private:
     /// Container for v6 vendor option definitions
     static VendorOptionDefContainers vendor6_defs_;
 
-    /// Container for additional option defnitions created in runtime.
+    /// Container for additional option definitions created in runtime.
     static util::StagedValue<OptionDefSpaceContainer> runtime_option_defs_;
 };
 

--- a/src/lib/dhcp/opaque_data_tuple.h
+++ b/src/lib/dhcp/opaque_data_tuple.h
@@ -114,7 +114,7 @@ public:
     /// @brief Assigns data to the tuple.
     ///
     /// This function replaces existing data in the tuple with the new data.
-    /// If the speficified buffer length is greater than the size of the buffer,
+    /// If the specified buffer length is greater than the size of the buffer,
     /// the behavior of this function is undefined.
     /// @param data Iterator pointing to the beginning of the buffer being
     /// assigned. The source buffer may be an STL object or an array of
@@ -179,7 +179,7 @@ public:
     /// and writes it to the specified buffer. The new are appended to the
     /// buffer, so as data existing in the buffer is preserved.
     ///
-    /// The tuple is considered malformed if one of the follwing occurs:
+    /// The tuple is considered malformed if one of the following occurs:
     /// - the size of the data is 0 (tuple is empty),
     /// - the size of the data is greater than 255 and the size of the length
     /// field is 1 byte (see @c LengthFieldType).

--- a/src/lib/dhcp/option4_client_fqdn.cc
+++ b/src/lib/dhcp/option4_client_fqdn.cc
@@ -52,9 +52,9 @@ public:
 
     /// @brief Constructor, from wire data.
     ///
-    /// @param first An iterator pointing to the begining of the option data
+    /// @param first An iterator pointing to the beginning of the option data
     /// in the wire format.
-    /// @param last An iterator poiting to the end of the option data in the
+    /// @param last An iterator pointing to the end of the option data in the
     /// wire format.
     Option4ClientFqdnImpl(OptionBufferConstIter first,
                           OptionBufferConstIter last);
@@ -92,9 +92,9 @@ public:
 
     /// @brief Parse the Option provided in the wire format.
     ///
-    /// @param first An iterator pointing to the begining of the option data
+    /// @param first An iterator pointing to the beginning of the option data
     /// in the wire format.
-    /// @param last An iterator poiting to the end of the option data in the
+    /// @param last An iterator pointing to the end of the option data in the
     /// wire format.
     void parseWireData(OptionBufferConstIter first,
                        OptionBufferConstIter last);
@@ -106,9 +106,9 @@ public:
 
     /// @brief Parse domain-name emcoded in the deprecated ASCII format.
     ///
-    /// @param first An iterator pointing to the begining of the option data
+    /// @param first An iterator pointing to the beginning of the option data
     /// where domain-name is stored.
-    /// @param last An iterator poiting to the end of the option data where
+    /// @param last An iterator pointing to the end of the option data where
     /// domain-name is stored.
     void parseASCIIDomainName(OptionBufferConstIter first,
                               OptionBufferConstIter last);
@@ -121,7 +121,7 @@ Option4ClientFqdnImpl(const uint8_t flags,
                       const std::string& domain_name,
                       // cppcheck 1.57 complains that const enum value is not passed
                       // by reference. Note that, it accepts the non-const enum value
-                      // to be passed by value. In both cases it is unneccessary to
+                      // to be passed by value. In both cases it is unnecessary to
                       // pass the enum by reference.
                       // cppcheck-suppress passedByValue
                       const Option4ClientFqdn::DomainNameType name_type)
@@ -188,7 +188,7 @@ Option4ClientFqdnImpl::
 setDomainName(const std::string& domain_name,
               // cppcheck 1.57 complains that const enum value is not passed
               // by reference. Note that, it accepts the non-const enum
-              // to be passed by value. In both cases it is unneccessary to
+              // to be passed by value. In both cases it is unnecessary to
               // pass the enum by reference.
               // cppcheck-suppress passedByValue
               const Option4ClientFqdn::DomainNameType name_type) {

--- a/src/lib/dhcp/option6_client_fqdn.cc
+++ b/src/lib/dhcp/option6_client_fqdn.cc
@@ -47,9 +47,9 @@ public:
 
     /// @brief Constructor, from wire data.
     ///
-    /// @param first An iterator pointing to the begining of the option data
+    /// @param first An iterator pointing to the beginning of the option data
     /// in the wire format.
-    /// @param last An iterator poiting to the end of the option data in the
+    /// @param last An iterator pointing to the end of the option data in the
     /// wire format.
     Option6ClientFqdnImpl(OptionBufferConstIter first,
                           OptionBufferConstIter last);
@@ -87,9 +87,9 @@ public:
 
     /// @brief Parse the Option provided in the wire format.
     ///
-    /// @param first An iterator pointing to the begining of the option data
+    /// @param first An iterator pointing to the beginning of the option data
     /// in the wire format.
-    /// @param last An iterator poiting to the end of the option data in the
+    /// @param last An iterator pointing to the end of the option data in the
     /// wire format.
     void parseWireData(OptionBufferConstIter first,
                        OptionBufferConstIter last);

--- a/src/lib/dhcp/option6_iaprefix.h
+++ b/src/lib/dhcp/option6_iaprefix.h
@@ -44,7 +44,7 @@ namespace dhcp {
 /// that the prefixes from the string are created locally (not received over the
 /// wire) and should be validated before the option is created. If we wanted
 /// to set non-significant bits to 0 when the prefix is created from the textual
-/// format it would have some peformance implications, because the option would
+/// format it would have some performance implications, because the option would
 /// need to be turned into wire format, appropriate bits set to 0 and then
 /// option would need to be created again from the wire format. We may consider
 /// doing it if we find a use case where it is required.

--- a/src/lib/dhcp/option_custom.cc
+++ b/src/lib/dhcp/option_custom.cc
@@ -523,7 +523,7 @@ void
 OptionCustom::writeFqdn(const std::string& fqdn, const uint32_t index) {
     checkIndex(index);
 
-    // Create a temporay buffer where the FQDN will be written.
+    // Create a temporary buffer where the FQDN will be written.
     OptionBuffer buf;
     // Try to write to the temporary buffer rather than to the
     // buffers_ member directly guarantees that we don't modify
@@ -531,7 +531,7 @@ OptionCustom::writeFqdn(const std::string& fqdn, const uint32_t index) {
     // is valid.
     OptionDataTypeUtil::writeFqdn(fqdn, buf);
     // If we got to this point it means that the FQDN is valid.
-    // We can move the contents of the teporary buffer to the
+    // We can move the contents of the temporary buffer to the
     // target buffer.
     std::swap(buffers_[index], buf);
 }

--- a/src/lib/dhcp/option_data_types.h
+++ b/src/lib/dhcp/option_data_types.h
@@ -341,7 +341,7 @@ public:
     /// @brief Get data type buffer length.
     ///
     /// This function returns the size of a particular data type.
-    /// Values retured by this function correspond to the data type
+    /// Values returned by this function correspond to the data type
     /// sizes defined in OptionDataTypeTraits (IPV4_ADDRESS_TYPE and
     /// IPV6_ADDRESS_TYPE are exceptions here) so they rather indicate
     /// the fixed length of the data being written into the buffer,

--- a/src/lib/dhcp/option_definition.cc
+++ b/src/lib/dhcp/option_definition.cc
@@ -438,7 +438,7 @@ OptionDefinition::haveOpaqueDataTuplesFormat() const {
 
 bool
 OptionDefinition::convertToBool(const std::string& value_str) const {
-    // Case insensitve check that the input is one of: "true" or "false".
+    // Case-insensitive check that the input is one of: "true" or "false".
     if (boost::iequals(value_str, "true")) {
         return (true);
 

--- a/src/lib/dhcp/option_definition.h
+++ b/src/lib/dhcp/option_definition.h
@@ -102,7 +102,7 @@ class OptionIntArray;
 /// option type is used. In such cases the data field types within the record
 /// are specified using \ref OptionDefinition::addRecordField.
 ///
-/// When the OptionDefinition object has been sucessfully created, it can be
+/// When the OptionDefinition object has been successfully created, it can be
 /// queried to return the appropriate option factory function for the specified
 /// specified option format. There are a number of "standard" factory functions
 /// that cover well known (common) formats.  If the particular format does not

--- a/src/lib/dhcp/option_space_container.h
+++ b/src/lib/dhcp/option_space_container.h
@@ -71,7 +71,7 @@ public:
     /// @return a list of option spaces.
     ///
     /// @todo This function is likely to be removed once
-    /// we create a structore of OptionSpaces defined
+    /// we create a structure of OptionSpaces defined
     /// through the configuration manager.
     std::list<Selector> getOptionSpaceNames() const {
         std::list<Selector> names;

--- a/src/lib/dhcp/option_string.h
+++ b/src/lib/dhcp/option_string.h
@@ -89,7 +89,7 @@ public:
     ///
     /// This function decodes option data from the provided buffer. Note that
     /// it does not decode the option code and length, so the iterators must
-    /// point to the begining and end of the option payload respectively.
+    /// point to the beginning and end of the option payload respectively.
     /// The size of the decoded payload must be at least 1 byte.
     ///
     /// @param begin the iterator pointing to the option payload.

--- a/src/lib/dhcp/option_vendor_class.cc
+++ b/src/lib/dhcp/option_vendor_class.cc
@@ -167,7 +167,7 @@ OptionVendorClass::toText(int indent) const {
 
     // Apply indentation
     s << std::string(indent, ' ');
-    // Print type, length and first occurence of enterprise id.
+    // Print type, length and first occurrence of enterprise id.
     s << "type=" << getType() << ", len=" << len() - getHeaderLen() << ", "
         " enterprise id=0x" << std::hex << getVendorId() << std::dec;
     // Iterate over all tuples and print their size and contents.

--- a/src/lib/dhcp/option_vendor_class.h
+++ b/src/lib/dhcp/option_vendor_class.h
@@ -24,7 +24,7 @@ namespace dhcp {
 /// The format of DHCPv6 Vendor Class option (16) is described in section 22.16
 /// of RFC3315 and the format of the DHCPv4 V-I Vendor Class option (124) is
 /// described in section 3 of RFC3925. Each of these options carries enterprise
-/// id followed by the collection of tuples carring opaque data. A single tuple
+/// id followed by the collection of tuples carrying opaque data. A single tuple
 /// consists of the field holding opaque data length and the actual data.
 /// In case of the DHCPv4 V-I Vendor Class each tuple is preceded by the
 /// 4-byte long enterprise id. Also, the field which carries the length of

--- a/src/lib/dhcp/pkt6.cc
+++ b/src/lib/dhcp/pkt6.cc
@@ -314,7 +314,7 @@ Pkt6::packUDP() {
 
         }
 
-        // DHCPv6 header: message-type (1 octect) + transaction id (3 octets)
+        // DHCPv6 header: message-type (1 octet) + transaction id (3 octets)
         buffer_out_.writeUint8(msg_type_);
         // store 3-octet transaction-id
         buffer_out_.writeUint8( (transid_ >> 16) & 0xff );

--- a/src/lib/dhcp/pkt_filter_bpf.cc
+++ b/src/lib/dhcp/pkt_filter_bpf.cc
@@ -26,7 +26,7 @@ const unsigned int MAX_BPF_OPEN_ATTEMPTS = 100;
 /// received on local loopback interface.
 const unsigned int BPF_LOCAL_LOOPBACK_HEADER_LEN = 4;
 
-/// The following structure defines a Berkely Packet Filter program to perform
+/// The following structure defines a Berkeley Packet Filter program to perform
 /// packet filtering. The program operates on Ethernet packets.  To help with
 /// interpretation of the program, for the types of Ethernet packets we are
 /// interested in, the header layout is:
@@ -229,7 +229,7 @@ PktFilterBPF::openSocket(Iface& iface,
 
     // Open fallback socket first. If it fails, it will give us an indication
     // that there is another service (perhaps DHCP server) running.
-    // The function will throw an exception and effectivelly cease opening
+    // The function will throw an exception and effectively cease opening
     // the BPF device below.
     int fallback = openFallbackSocket(addr, port);
 
@@ -310,7 +310,7 @@ PktFilterBPF::openSocket(Iface& iface,
         close(fallback);
         close(sock);
         isc_throw(SocketConfigError, "Unable to obtain the required"
-                  " buffer legth for reads from BPF device");
+                  " buffer length for reads from BPF device");
     }
 
     if (buf_len < sizeof(bpf_hdr)) {
@@ -355,14 +355,14 @@ PktFilterBPF::openSocket(Iface& iface,
     }
 
     // Configure the BPF device to use the immediate mode. This ensures
-    // that the read function returns immediatelly, instead of waiting
+    // that the read function returns immediately, instead of waiting
     // for the kernel to fill up the buffer, which would likely cause
     // read hangs.
     int flag = 1;
     if (ioctl(sock, BIOCIMMEDIATE, &flag) < 0) {
         close(fallback);
         close(sock);
-        isc_throw(SocketConfigError, "Failed to set promiscious mode for"
+        isc_throw(SocketConfigError, "Failed to set promiscuous mode for"
                   " BPF device");
     }
 
@@ -411,10 +411,10 @@ PktFilterBPF::receive(Iface& iface, const SocketInfo& socket_info) {
     datalen = read(socket_info.sockfd_, iface.getReadBuffer(),
                    iface.getReadBufferSize());
     // If negative value is returned by read(), it indicates that an
-    // error occured. If returned value is 0, no data was read from the
+    // error occurred. If returned value is 0, no data was read from the
     // socket. In both cases something has gone wrong, because we expect
     // that a chunk of data is there. We signal the lack of data by
-    // returing an empty packet.
+    // returning an empty packet.
     if (datalen <= 0) {
         return Pkt4Ptr();
     }

--- a/src/lib/dhcp/pkt_filter_bpf.h
+++ b/src/lib/dhcp/pkt_filter_bpf.h
@@ -46,7 +46,7 @@ namespace dhcp {
 /// In nutshell, the BPF device is created by opening the file /dev/bpf%d
 /// where %d is a number. The BPF device is configured by issuing ioctl
 /// commands listed here: http://www.freebsd.org/cgi/man.cgi?bpf(4).
-/// The specific configuration used by Kea DHCP server is decribed in
+/// The specific configuration used by Kea DHCP server is described in
 /// documentation of @c PktFilterBPF::openSocket.
 ///
 /// Use of BPF requires Kea to encode and decode the datalink and network
@@ -73,7 +73,7 @@ public:
     /// - set filter program to receive DHCP messages encapsulated in UDP
     /// packets
     /// - set immediate mode which causes the read function to return
-    /// immediatelly and do not wait for the whole read buffer to be filled
+    /// immediately and do not wait for the whole read buffer to be filled
     /// by the kernel (to avoid hangs)
     ///
     /// It also obtains the following configuration from the kernel:

--- a/src/lib/dhcp/pkt_filter_inet.h
+++ b/src/lib/dhcp/pkt_filter_inet.h
@@ -15,7 +15,7 @@ namespace dhcp {
 
 /// @brief Packet handling class using AF_INET socket family
 ///
-/// This class provides methods to send and recive packet via socket using
+/// This class provides methods to send and receive packet via socket using
 /// AF_INET family and SOCK_DGRAM type.
 class PktFilterInet : public PktFilter {
 public:
@@ -28,7 +28,7 @@ public:
     /// @brief Check if packet can be sent to the host without address directly.
     ///
     /// This Packet Filter sends packets through AF_INET datagram sockets, so
-    /// it can't inject the HW address of the destionation host into the packet.
+    /// it can't inject the HW address of the destination host into the packet.
     /// Therefore this class does not support direct responses.
     ///
     /// @return false always.
@@ -61,7 +61,7 @@ public:
     /// @return Received packet
     /// @throw isc::dhcp::SocketReadError if an error occurs during reception
     /// of the packet.
-    /// @throw An execption thrown by the isc::dhcp::Pkt4 object if DHCPv4
+    /// @throw An exception thrown by the isc::dhcp::Pkt4 object if DHCPv4
     /// message parsing fails.
     virtual Pkt4Ptr receive(Iface& iface, const SocketInfo& socket_info);
 
@@ -72,7 +72,7 @@ public:
     /// @param pkt packet to be sent
     ///
     /// @return result of sending a packet. It is 0 if successful.
-    /// @throw isc::dhcp::SocketWriteError if an error occures during sending
+    /// @throw isc::dhcp::SocketWriteError if an error occurs during sending
     /// a DHCP message through the socket.
     virtual int send(const Iface& iface, uint16_t sockfd,
                      const Pkt4Ptr& pkt);

--- a/src/lib/dhcp/pkt_filter_inet6.h
+++ b/src/lib/dhcp/pkt_filter_inet6.h
@@ -41,7 +41,7 @@ public:
     /// group.
     ///
     /// @return A structure describing a primary and fallback socket.
-    /// @throw isc::dhcp::SocketConfigError if error occured when opening
+    /// @throw isc::dhcp::SocketConfigError if error occurred when opening
     /// or configuring a socket.
     virtual SocketInfo openSocket(const Iface& iface,
                                   const isc::asiolink::IOAddress& addr,
@@ -69,7 +69,7 @@ public:
 
     /// @brief Sends DHCPv6 message through a specified interface and socket.
     ///
-    /// Thie function sends a DHCPv6 message through a specified interface and
+    /// The function sends a DHCPv6 message through a specified interface and
     /// socket. In general, there may be multiple sockets open on a single
     /// interface as a single interface may have multiple IPv6 addresses.
     ///
@@ -78,7 +78,7 @@ public:
     /// @param pkt A packet to be sent.
     ///
     /// @return A result of sending the message. It is 0 if successful.
-    /// @throw isc::dhcp::SocketWriteError if error occured when sending a
+    /// @throw isc::dhcp::SocketWriteError if error occurred when sending a
     /// packet.
     virtual int send(const Iface& iface, uint16_t sockfd,
                      const Pkt6Ptr& pkt);

--- a/src/lib/dhcp/pkt_filter_lpf.cc
+++ b/src/lib/dhcp/pkt_filter_lpf.cc
@@ -21,7 +21,7 @@ namespace {
 
 using namespace isc::dhcp;
 
-/// The following structure defines a Berkely Packet Filter program to perform
+/// The following structure defines a Berkeley Packet Filter program to perform
 /// packet filtering. The program operates on Ethernet packets.  To help with
 /// interpretation of the program, for the types of Ethernet packets we are
 /// interested in, the header layout is:
@@ -136,7 +136,7 @@ PktFilterLPF::openSocket(Iface& iface,
 
     // Open fallback socket first. If it fails, it will give us an indication
     // that there is another service (perhaps DHCP server) running.
-    // The function will throw an exception and effectivelly cease opening
+    // The function will throw an exception and effectively cease opening
     // raw socket below.
     int fallback = openFallbackSocket(addr, port);
 
@@ -227,10 +227,10 @@ PktFilterLPF::receive(Iface& iface, const SocketInfo& socket_info) {
     // have to get the data from the raw socket too.
     int data_len = read(socket_info.sockfd_, raw_buf, sizeof(raw_buf));
     // If negative value is returned by read(), it indicates that an
-    // error occured. If returned value is 0, no data was read from the
+    // error occurred. If returned value is 0, no data was read from the
     // socket. In both cases something has gone wrong, because we expect
     // that a chunk of data is there. We signal the lack of data by
-    // returing an empty packet.
+    // returning an empty packet.
     if (data_len <= 0) {
         return Pkt4Ptr();
     }

--- a/src/lib/dhcp/pkt_filter_lpf.h
+++ b/src/lib/dhcp/pkt_filter_lpf.h
@@ -16,7 +16,7 @@ namespace dhcp {
 
 /// @brief Packet handling class using Linux Packet Filtering
 ///
-/// This class provides methods to send and recive DHCPv4 messages using raw
+/// This class provides methods to send and receive DHCPv4 messages using raw
 /// sockets and Linux Packet Filtering. It is used by @c isc::dhcp::IfaceMgr
 /// to send DHCPv4 messages to the hosts which don't have an IPv4 address
 /// assigned yet.

--- a/src/lib/dhcp/protocol_util.h
+++ b/src/lib/dhcp/protocol_util.h
@@ -15,7 +15,7 @@
 namespace isc {
 namespace dhcp {
 
-/// @brief Exception thrown when error occured during parsing packet's headers.
+/// @brief Exception thrown when error occurred during parsing packet's headers.
 ///
 /// This exception is thrown when parsing link, Internet or Transport layer
 /// header has failed.

--- a/src/lib/dhcp/std_option_defs.h
+++ b/src/lib/dhcp/std_option_defs.h
@@ -215,7 +215,7 @@ const OptionDefParams STANDARD_V4_OPTION_DEFINITIONS[] = {
     { "vivso-suboptions", DHO_VIVSO_SUBOPTIONS, OPT_UINT32_TYPE,
       false, NO_RECORD_DEF, "" }
 
-        // @todo add definitions for all remaning options.
+        // @todo add definitions for all remaining options.
 };
 
 /// Number of option definitions defined.
@@ -269,9 +269,9 @@ RECORD_DECL(CLIENT_NII_RECORDS, OPT_UINT8_TYPE, OPT_UINT8_TYPE, OPT_UINT8_TYPE);
 ///
 /// @warning in this array, the initializers are provided for all
 /// OptionDefParams struct's members despite initializers for
-/// 'records' and 'record_size' could be ommited for entries for
+/// 'records' and 'record_size' could be omitted for entries for
 /// which 'type' does not equal to OPT_RECORD_TYPE. If initializers
-/// are ommitted the corresponding values should default to 0.
+/// are omitted the corresponding values should default to 0.
 /// This however does not work on Solaris (GCC) which issues a
 /// warning about lack of initializers for some struct members
 /// causing build to fail.

--- a/src/lib/dhcp/tests/duid_factory_unittest.cc
+++ b/src/lib/dhcp/tests/duid_factory_unittest.cc
@@ -347,7 +347,7 @@ TEST_F(DUIDFactoryTest, createLLTExplicitHtype) {
 }
 
 // This test verifies that the factory class creates DUID-LLT from
-// explcitly specified link layer address, when other parameters
+// explicitly specified link layer address, when other parameters
 // are generated.
 TEST_F(DUIDFactoryTest, createLLTExplicitLinkLayerAddress) {
     ASSERT_NO_THROW(factory().createLLT(0, 0, toVector("121212121212")));

--- a/src/lib/dhcp/tests/iface_mgr_test_config.h
+++ b/src/lib/dhcp/tests/iface_mgr_test_config.h
@@ -194,7 +194,7 @@ public:
     ///
     /// The test uses stub implementation of packet filter object. It is
     /// possible to configure that object to report having a capability
-    /// to directly repond to clients which don't have an address yet.
+    /// to directly respond to clients which don't have an address yet.
     /// This function sets this property for packet filter object.
     ///
     /// @param direct_resp Value to be set.

--- a/src/lib/dhcp/tests/iface_mgr_unittest.cc
+++ b/src/lib/dhcp/tests/iface_mgr_unittest.cc
@@ -119,7 +119,7 @@ TEST(IfaceTest, countActive4) {
 /// TestPktFilter::receive will never be called. The appropriate extension
 /// to IfaceMgr is planned along with implementation of other "Packet
 /// Filters" such as these supporting Linux Packet Filtering and
-/// Berkley Packet Filtering.
+/// Berkeley Packet Filtering.
 class TestPktFilter : public PktFilter {
 public:
 
@@ -210,7 +210,7 @@ public:
     /// @brief Returns the collection of existing interfaces.
     IfaceCollection& getIfacesLst() { return (ifaces_); }
 
-    /// @brief This function creates fictitious interfaces with fictious
+    /// @brief This function creates fictitious interfaces with fictitious
     /// addresses.
     ///
     /// These interfaces can be used in tests that don't actually try
@@ -390,7 +390,7 @@ public:
 #endif
     }
 
-    // Get ther number of IPv4 or IPv6 sockets on the loopback interface
+    // Get the number of IPv4 or IPv6 sockets on the loopback interface
     int getOpenSocketsCount(const Iface& iface, uint16_t family) const {
         // Get all sockets.
         Iface::SocketCollection sockets = iface.getSockets();
@@ -833,7 +833,7 @@ TEST_F(IfaceMgrTest, multipleSockets) {
         cout << "Local loopback interface not found. Skipping test. " << endl;
         return;
     }
-    // Once sockets have been sucessfully opened, they are supposed to
+    // Once sockets have been successfully opened, they are supposed to
     // be on the list. Here we start to test if all expected sockets
     // are on the list and no other (unexpected) socket is there.
     Iface::SocketCollection sockets = iface_ptr->getSockets();
@@ -874,7 +874,7 @@ TEST_F(IfaceMgrTest, multipleSockets) {
     sockets = iface_ptr->getSockets();
     ASSERT_EQ(0, sockets.size());
 
-    // We are still in posession of socket descriptors that we created
+    // We are still in possession of socket descriptors that we created
     // on the beginning of this test. We can use them to check whether
     // closeSockets() only removed them from the list or they have been
     // really closed.
@@ -1209,7 +1209,7 @@ TEST_F(IfaceMgrTest, sendReceive4) {
     // skip checking source port of sent address.
 
     // Close the socket. Further we will test if errors are reported
-    // properly on attempt to use closed soscket.
+    // properly on attempt to use closed socket.
     close(socket1);
 
 // Warning: kernel bug on FreeBSD. The following code checks that attempt to
@@ -1226,7 +1226,7 @@ TEST_F(IfaceMgrTest, sendReceive4) {
 //
 // @todo: This part of the test is currently disabled on all BSD systems as it was
 // the quick fix. We need a more elegant (config-based) solution to disable
-// this check on affected systems only. The ticket has been submited for this
+// this check on affected systems only. The ticket has been submitted for this
 // work: http://kea.isc.org/ticket/2971
 #ifndef OS_BSD
     EXPECT_THROW(ifacemgr->receive4(10), SocketReadError);
@@ -1399,11 +1399,11 @@ TEST_F(IfaceMgrTest, checkPacketFilterRawSocket) {
 
 // Note: This test will only run on non-Linux and non-BSD systems.
 // This test checks whether it is possible to use IfaceMgr to figure
-// out which Pakcket Filter object should be used when direct responses
+// out which Packet Filter object should be used when direct responses
 // to hosts, having no address assigned are desired or not desired.
 // Since direct responses aren't supported on systems other than Linux
 // and BSD the function under test should always set object of
-// PktFilterInet type as current Packet Filter. This object does not 
+// PktFilterInet type as current Packet Filter. This object does not
 //support direct responses. Once implementation is added on systems
 // other than BSD and Linux the OS specific version of the test will
 // be removed.
@@ -1599,7 +1599,7 @@ TEST_F(IfaceMgrTest, openSocket4ErrorHandler) {
     // open and bound to the same address and port. An attempt to open
     // another socket and bind to this address and port should fail.
     ASSERT_NO_THROW(ifacemgr.openSockets4(DHCP4_SERVER_PORT, true, error_handler));
-    // We expect that an error occured when we tried to open a socket on
+    // We expect that an error occurred when we tried to open a socket on
     // eth0, but the socket on eth1 should open just fine.
     EXPECT_EQ(1, errors_count_);
 
@@ -1712,7 +1712,7 @@ TEST_F(IfaceMgrTest, openSockets6NoLinkLocal) {
 
     // Check that the number of sockets is correct on each interface.
     checkSocketsCount6(*ifacemgr.getIface("lo"), 0);
-    // The thrid parameter specifies that the number of link-local
+    // The third parameter specifies that the number of link-local
     // addresses for eth0 is equal to 0.
     checkSocketsCount6(*ifacemgr.getIface("eth0"), 0, 0);
     checkSocketsCount6(*ifacemgr.getIface("eth1"), 0, 1);
@@ -1731,7 +1731,7 @@ TEST_F(IfaceMgrTest, openSockets6NoLinkLocal) {
 
 }
 
-// This test checks that socket is open on the non-muticast-capable
+// This test checks that socket is open on the non-multicast-capable
 // interface. This socket simply doesn't join multicast group.
 TEST_F(IfaceMgrTest, openSockets6NotMulticast) {
     NakedIfaceMgr ifacemgr;
@@ -2014,7 +2014,7 @@ TEST_F(IfaceMgrTest, openSocket6ErrorHandler) {
     // opened on eth0 and an attempt to open another socket and bind to
     // the same address and port should fail.
     ASSERT_NO_THROW(ifacemgr.openSockets6(DHCP6_SERVER_PORT, error_handler));
-    // We expect that an error occured when we tried to open a socket on
+    // We expect that an error occurred when we tried to open a socket on
     // eth0, but the socket on eth1 should open just fine.
     EXPECT_EQ(1, errors_count_);
 
@@ -2387,7 +2387,7 @@ TEST_F(IfaceMgrTest, detectIfaces) {
     NakedIfaceMgr ifacemgr;
 
     // We are using struct ifaddrs as it is the only good portable one
-    // ifreq and ioctls are far from portabe. For BSD ifreq::ifa_flags field
+    // ifreq and ioctls are far from portable. For BSD ifreq::ifa_flags field
     // is only a short which, nowadays, can be negative
     struct ifaddrs *iflist = 0, *ifptr = 0;
     ASSERT_EQ(0, getifaddrs(&iflist))

--- a/src/lib/dhcp/tests/libdhcp++_unittest.cc
+++ b/src/lib/dhcp/tests/libdhcp++_unittest.cc
@@ -490,7 +490,7 @@ TEST_F(LibDhcpTest, unpackOptions6) {
     ASSERT_TRUE(opt_oro);
     // Get set of uint16_t values.
     std::vector<uint16_t> opts = opt_oro->getValues();
-    // Prepare the refrence data.
+    // Prepare the reference data.
     std::vector<uint16_t> expected_opts;
     expected_opts.push_back(0x6C6D); // equivalent to: 108, 109
     expected_opts.push_back(0x6E6F); // equivalent to 110, 111
@@ -718,7 +718,7 @@ TEST_F(LibDhcpTest, packOptions4) {
     // we want to use this buffer as a reference to verify that produced
     // option in on-wire format is correct.
 
-    // Create Ciruit ID sub-option and add to RAI.
+    // Create Circuit ID sub-option and add to RAI.
     OptionPtr circuit_id(new Option(Option::V4, RAI_OPTION_AGENT_CIRCUIT_ID,
                                     OptionBuffer(v4_opts + 46,
                                                  v4_opts + 50)));
@@ -736,7 +736,7 @@ TEST_F(LibDhcpTest, packOptions4) {
 
     isc::dhcp::OptionCollection opts; // list of options
     // Note that we insert each option under the same option code into
-    // the map. This gurantees that options are packed in the same order
+    // the map. This guarantees that options are packed in the same order
     // they were added. Otherwise, options would get sorted by code and
     // the resulting buffer wouldn't match with the reference buffer.
     opts.insert(make_pair(opt1->getType(), opt1));

--- a/src/lib/dhcp/tests/opaque_data_tuple_unittest.cc
+++ b/src/lib/dhcp/tests/opaque_data_tuple_unittest.cc
@@ -386,7 +386,7 @@ TEST(OpaqueDataTuple, unpack1ByteZeroLength) {
     EXPECT_EQ(0, tuple.getLength());
 }
 
-// This test verfifies that exception is thrown if the empty buffer is being
+// This test verifies that exception is thrown if the empty buffer is being
 // parsed.
 TEST(OpaqueDataTuple, unpack1ByteEmptyBuffer) {
     OpaqueDataTuple tuple(OpaqueDataTuple::LENGTH_1_BYTE);

--- a/src/lib/dhcp/tests/option6_ia_unittest.cc
+++ b/src/lib/dhcp/tests/option6_ia_unittest.cc
@@ -80,7 +80,7 @@ public:
         EXPECT_EQ(12, opt->len() - opt->getHeaderLen());
         EXPECT_EQ(type, opt->getType());
 
-        EXPECT_EQ(16, outBuf_.getLength()); // lenght(IA_NA) = 16
+        EXPECT_EQ(16, outBuf_.getLength()); // length(IA_NA) = 16
 
         // Check if pack worked properly:
         InputBuffer out(outBuf_.getData(), outBuf_.getLength());

--- a/src/lib/dhcp/tests/option_definition_unittest.cc
+++ b/src/lib/dhcp/tests/option_definition_unittest.cc
@@ -137,7 +137,7 @@ TEST_F(OptionDefinitionTest, copyConstructor) {
     EXPECT_EQ("isc", opt_def_copy2.getEncapsulatedSpace());
 }
 
-// This test checks that two option definitions may be compared fot equality.
+// This test checks that two option definitions may be compared for equality.
 TEST_F(OptionDefinitionTest, equality) {
     // Equal definitions.
     EXPECT_TRUE(OptionDefinition("option-foo", 5, "uint16", false)
@@ -741,7 +741,7 @@ TEST_F(OptionDefinitionTest, recordIAAddr6) {
 
 // The purpose of this test is to verify that definition can be created
 // for option that comprises record of data. In this particular test
-// the IAADDR option is used. The data for the option is speicifed as
+// the IAADDR option is used. The data for the option is specified as
 // a vector of strings. Each string carries the data for the corresponding
 // data field.
 TEST_F(OptionDefinitionTest, recordIAAddr6Tokenized) {

--- a/src/lib/dhcp/tests/option_int_unittest.cc
+++ b/src/lib/dhcp/tests/option_int_unittest.cc
@@ -131,7 +131,7 @@ public:
         // Data length is 2 bytes.
         EXPECT_EQ(2, opt->len() - opt->getHeaderLen());
         EXPECT_EQ(TEST_OPT_CODE, opt->getType());
-        // The total length is 2 bytes for data and 2 or 4 bytes for aheader.
+        // The total length is 2 bytes for data and 2 or 4 bytes for a header.
         if (u == Option::V4) {
             EXPECT_EQ(4, out_buf_.getLength());
         } else {

--- a/src/lib/dhcp/tests/option_space_unittest.cc
+++ b/src/lib/dhcp/tests/option_space_unittest.cc
@@ -60,7 +60,7 @@ TEST(OptionSpaceTest, validateName) {
     EXPECT_TRUE(OptionSpace::validateName("1234"));
     EXPECT_TRUE(OptionSpace::validateName("UPPER_CASE_allowed"));
 
-    // Negative test scenarions: empty strings, dots, spaces are not
+    // Negative test scenarios: empty strings, dots, spaces are not
     // allowed
     EXPECT_FALSE(OptionSpace::validateName(""));
     EXPECT_FALSE(OptionSpace::validateName(" "));

--- a/src/lib/dhcp/tests/option_unittest.cc
+++ b/src/lib/dhcp/tests/option_unittest.cc
@@ -131,7 +131,7 @@ TEST_F(OptionTest, v4_data2) {
     data.push_back(67);
 
     // Data contains extra garbage at beginning and at the end. It should be
-    // ignored, as we pass interators to proper data. Only subset (limited by
+    // ignored, as we pass iterators to proper data. Only subset (limited by
     // iterators) of the vector should be used.
     // expData contains expected content (just valid data, without garbage).
     scoped_ptr<Option> opt;

--- a/src/lib/dhcp/tests/pkt4_unittest.cc
+++ b/src/lib/dhcp/tests/pkt4_unittest.cc
@@ -684,7 +684,7 @@ TEST_F(Pkt4Test, unpackMalformed) {
     orig.push_back(0x53);
     orig.push_back(0x63);
 
-    orig.push_back(53); // Message Type 
+    orig.push_back(53); // Message Type
     orig.push_back(1); // length=1
     orig.push_back(2); // type=2
 
@@ -727,7 +727,7 @@ TEST_F(Pkt4Test, unpackVendorMalformed) {
     orig.push_back(0x53);
     orig.push_back(0x63);
 
-    orig.push_back(53); // Message Type 
+    orig.push_back(53); // Message Type
     orig.push_back(1); // length=1
     orig.push_back(2); // type=2
 
@@ -943,7 +943,7 @@ TEST_F(Pkt4Test, clientClasses) {
 TEST_F(Pkt4Test, getMAC) {
     Pkt4 pkt(DHCPOFFER, 1234);
 
-    // DHCPv4 packet by default doens't have MAC address specified.
+    // DHCPv4 packet by default doesn't have MAC address specified.
     EXPECT_FALSE(pkt.getMAC(HWAddr::HWADDR_SOURCE_ANY));
     EXPECT_FALSE(pkt.getMAC(HWAddr::HWADDR_SOURCE_RAW));
 
@@ -1093,7 +1093,7 @@ TEST_F(Pkt4Test, toText) {
     pkt.addOption(OptionPtr(new OptionUint32(Option::V4, 156, 123456)));
     pkt.addOption(OptionPtr(new OptionString(Option::V4, 87, "lorem ipsum")));
 
-    EXPECT_EQ("local_address=192.0.2.34:67, remote_adress=192.10.33.4:68, "
+    EXPECT_EQ("local_address=192.0.2.34:67, remote_address=192.10.33.4:68, "
               "msg_type=DHCPDISCOVER (1), transid=0x9ef,\n"
               "options:\n"
               "  type=053, len=001: 1 (uint8)\n"
@@ -1109,7 +1109,7 @@ TEST_F(Pkt4Test, toText) {
     pkt.delOption(87);
     pkt.delOption(53);
 
-    EXPECT_EQ("local_address=192.0.2.34:67, remote_adress=192.10.33.4:68, "
+    EXPECT_EQ("local_address=192.0.2.34:67, remote_address=192.10.33.4:68, "
               "msg_type=(missing), transid=0x9ef, "
               "message contains no options",
               pkt.toText());

--- a/src/lib/dhcp/tests/pkt6_unittest.cc
+++ b/src/lib/dhcp/tests/pkt6_unittest.cc
@@ -986,7 +986,7 @@ TEST_F(Pkt6Test, getAnyRelayOption) {
     EXPECT_TRUE(opt->equals(relay3_opt1));
     EXPECT_FALSE(opt == relay3_opt1);
     // Test that option copy has replaced the original option within the
-    // packet. We achive that by calling a variant of the method which
+    // packet. We achieve that by calling a variant of the method which
     // retrieved non-copied option.
     relay3_opt1 = msg->getNonCopiedAnyRelayOption(200, Pkt6::RELAY_SEARCH_FROM_CLIENT);
     ASSERT_TRUE(relay3_opt1);
@@ -1084,7 +1084,7 @@ TEST_F(Pkt6Test, clientClasses) {
 TEST_F(Pkt6Test, getMAC) {
     Pkt6 pkt(DHCPV6_ADVERTISE, 1234);
 
-    // DHCPv6 packet by default doens't have MAC address specified.
+    // DHCPv6 packet by default doesn't have MAC address specified.
     EXPECT_FALSE(pkt.getMAC(HWAddr::HWADDR_SOURCE_ANY));
     EXPECT_FALSE(pkt.getMAC(HWAddr::HWADDR_SOURCE_RAW));
 
@@ -1578,7 +1578,7 @@ TEST_F(Pkt6Test, getClientId) {
     EXPECT_TRUE(duid->getDuid() == duid_vec);
 }
 
-// This test verfies that it is possible to obtain the packet
+// This test verifies that it is possible to obtain the packet
 // identifiers (DUID, HW Address, transaction id) in the textual
 // format.
 TEST_F(Pkt6Test, makeLabel) {

--- a/src/lib/dhcp/tests/pkt_captures4.cc
+++ b/src/lib/dhcp/tests/pkt_captures4.cc
@@ -25,7 +25,7 @@
 /// 4. Right click on DHCPv6 -> Copy -> Bytes -> Hex Stream
 /// 5. Paste it as: string hex_string="[paste here]";
 /// 6. Coding guidelines line restrictions apply, so wrap your code as necessary
-/// 7. Make sure you decribe the capture appropriately
+/// 7. Make sure you describe the capture appropriately
 /// 8. Follow whatever rest of the methods are doing (set ports, ifaces etc.)
 /// 9. To easily copy packet description, click File... -> Extract packet
 ///    dissections -> as plain text file...

--- a/src/lib/dhcp/tests/pkt_captures6.cc
+++ b/src/lib/dhcp/tests/pkt_captures6.cc
@@ -25,7 +25,7 @@
 /// 4. Right click on DHCPv6 -> Copy -> Bytes -> Hex Stream
 /// 5. Paste it as: string hex_string="[paste here]";
 /// 6. Coding guidelines line restrictions apply, so wrap your code as necessary
-/// 7. Make sure you decribe the capture appropriately
+/// 7. Make sure you describe the capture appropriately
 /// 8. Follow whatever rest of the methods are doing (set ports, ifaces etc.)
 /// 9. To easily copy packet description, click File... -> Extract packet
 ///    dissections -> as plain text file...
@@ -55,7 +55,7 @@ Pkt6Ptr PktCaptures::captureSimpleSolicit() {
         1,  // type 1 = SOLICIT
         0xca, 0xfe, 0x01, // trans-id = 0xcafe01
         0, 1, // option type 1 (client-id)
-        0, 10, // option lenth 10
+        0, 10, // option length 10
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, // DUID
         0, 3, // option type 3 (IA_NA)
         0, 12, // option length 12

--- a/src/lib/dhcp/tests/pkt_filter_test_stub.h
+++ b/src/lib/dhcp/tests/pkt_filter_test_stub.h
@@ -32,7 +32,7 @@ public:
     ///
     /// This function checks if the direct response capability is supported,
     /// i.e. if the server can respond to the client which doesn't have an
-    /// address yet. For this dummy class, the true is alaways returned.
+    /// address yet. For this dummy class, the true is always returned.
     ///
     /// @return always true.
     virtual bool isDirectResponseSupported() const;
@@ -40,7 +40,7 @@ public:
     /// @brief Simulate opening of the socket.
     ///
     /// This function simulates opening a primary socket. Rather than open
-    /// an actual socket, the stub peforms a read-only open of "/dev/null".
+    /// an actual socket, the stub performs a read-only open of "/dev/null".
     /// The fd returned by this open saved as the socket's descriptor in the
     /// SocketInfo structure.  This way the filter consumes an actual
     /// descriptor and retains it until its socket is closed.

--- a/src/lib/dhcp/tests/pkt_filter_test_utils.h
+++ b/src/lib/dhcp/tests/pkt_filter_test_utils.h
@@ -105,7 +105,7 @@ public:
     ///
     /// This function checks if the direct response capability is supported,
     /// i.e. if the server can respond to the client which doesn't have an
-    /// address yet. For this dummy class, the true is alaways returned.
+    /// address yet. For this dummy class, the true is always returned.
     ///
     /// @return always true.
     virtual bool isDirectResponseSupported() const;

--- a/src/lib/dhcp/tests/pkt_filter_unittest.cc
+++ b/src/lib/dhcp/tests/pkt_filter_unittest.cc
@@ -29,7 +29,7 @@ public:
     }
 };
 
-// This test verifies that the fallback socket is successfuly opened and
+// This test verifies that the fallback socket is successfully opened and
 // bound using the protected function of the PktFilter class.
 TEST_F(PktFilterBaseClassTest, openFallbackSocket) {
     // Open socket using the function under test. Note that, we don't have to

--- a/src/lib/dhcp_ddns/ncr_io.cc
+++ b/src/lib/dhcp_ddns/ncr_io.cc
@@ -189,8 +189,8 @@ NameChangeSender::startSending(isc::asiolink::IOService& io_service) {
 
 void
 NameChangeSender::stopSending() {
-    // Set it send indicator to false, no matter what. This allows us to at 
-    // least try to re-open via startSending(). Also, setting it false now, 
+    // Set it send indicator to false, no matter what. This allows us to at
+    // least try to re-open via startSending(). Also, setting it false now,
     // allows us to break sendNext() chain in invokeSendHandler.
     setSending(false);
 
@@ -393,7 +393,7 @@ NameChangeSender::runReadyIO() {
     }
 
     // We shouldn't be here if IO isn't ready to execute.
-    // By running poll we're gauranteed not to hang.
+    // By running poll we're guaranteed not to hang.
     /// @todo Trac# 3325 requests that asiolink::IOService provide a
     /// wrapper for poll().
     io_service_->get_io_service().poll_one();

--- a/src/lib/dhcp_ddns/ncr_io.h
+++ b/src/lib/dhcp_ddns/ncr_io.h
@@ -550,7 +550,7 @@ public:
     ///
     /// @throw NcrSenderError if either sender is in send mode, if the number of
     /// messages in the source sender's queue is larger than this sender's
-    /// maxium queue size, or if this sender's queue is not empty.
+    /// maximum queue size, or if this sender's queue is not empty.
     void assumeQueue(NameChangeSender& source_sender);
 
     /// @brief Returns a file descriptor suitable for use with select
@@ -754,7 +754,7 @@ private:
     /// @brief Boolean indicator which tracks sending status.
     bool sending_;
 
-    /// @brief A pointer to regisetered send completion handler.
+    /// @brief A pointer to registered send completion handler.
     RequestSendHandler& send_handler_;
 
     /// @brief Maximum number of entries permitted in the send queue.

--- a/src/lib/dhcp_ddns/ncr_msg.h
+++ b/src/lib/dhcp_ddns/ncr_msg.h
@@ -33,7 +33,7 @@ public:
         isc::Exception(file, line, what) { };
 };
 
-/// @brief Exception thrown when there is an error occured during computation
+/// @brief Exception thrown when there is an error occurred during computation
 /// of the DHCID.
 class DhcidRdataComputeError : public isc::Exception {
 public:
@@ -180,14 +180,14 @@ public:
         return (this->bytes_ != other.bytes_);
     }
 
-    /// @brief Compares two D2Dhcids lexcially
+    /// @brief Compares two D2Dhcids lexically
     bool operator<(const D2Dhcid& other) const {
         return (this->bytes_ < other.bytes_);
     }
 
 private:
 
-    /// @brief Creates the DHCID using specified indetifier.
+    /// @brief Creates the DHCID using specified identifier.
     ///
     /// This function creates the DHCID RDATA as specified in RFC4701,
     /// section 3.5.

--- a/src/lib/dhcp_ddns/ncr_udp.cc
+++ b/src/lib/dhcp_ddns/ncr_udp.cc
@@ -235,7 +235,7 @@ NameChangeUDPSender::open(isc::asiolink::IOService& io_service) {
             asio_socket_->set_option(boost::asio::socket_base::reuse_address(true));
         }
 
-        // Bind the low leve socket to our endpoint.
+        // Bind the low level socket to our endpoint.
         asio_socket_->bind(endpoint.getASIOEndpoint());
     } catch (boost::system::system_error& ex) {
         isc_throw (NcrUDPError, ex.code().message());

--- a/src/lib/dhcp_ddns/tests/ncr_udp_unittests.cc
+++ b/src/lib/dhcp_ddns/tests/ncr_udp_unittests.cc
@@ -738,7 +738,7 @@ TEST(NameChangeUDPSenderBasicTest, watchClosedBeforeSendRequest) {
     // Tamper with the watch socket by closing the select-fd.
     close(sender.getSelectFd());
 
-    // Send should fail as we interferred by closing the select-fd.
+    // Send should fail as we interfered by closing the select-fd.
     ASSERT_THROW(sender.sendRequest(ncr), util::WatchSocketError);
 
     // Verify we didn't invoke the handler.
@@ -775,7 +775,7 @@ TEST(NameChangeUDPSenderBasicTest, watchClosedAfterSendRequest) {
     close (sender.getSelectFd());
 
     // Run one handler. This should execute the send completion handler
-    // after sending the first message.  Duing completion handling, we will
+    // after sending the first message.  Doing completion handling, we will
     // attempt to queue the second message which should fail.
     ASSERT_NO_THROW(sender.runReadyIO());
 
@@ -822,7 +822,7 @@ TEST(NameChangeUDPSenderBasicTest, watchSocketBadRead) {
     ASSERT_NE(util::WatchSocket::MARKER, buf);
 
     // Run one handler. This should execute the send completion handler
-    // after sending the message.  Duing completion handling clearing the
+    // after sending the message.  Doing completion handling clearing the
     // watch socket should fail, which will close the socket, but not
     // result in a throw.
     ASSERT_NO_THROW(sender.runReadyIO());

--- a/src/lib/dhcpsrv/alloc_engine.cc
+++ b/src/lib/dhcpsrv/alloc_engine.cc
@@ -253,7 +253,7 @@ AllocEngine::AllocEngine(AllocType engine_type, uint64_t attempts,
     // Choose the basic (normal address) lease type
     Lease::Type basic_type = ipv6 ? Lease::TYPE_NA : Lease::TYPE_V4;
 
-    // Initalize normal address allocators
+    // Initialize normal address allocators
     switch (engine_type) {
     case ALLOC_ITERATIVE:
         allocators_[basic_type] = AllocatorPtr(new IterativeAllocator(basic_type));
@@ -268,7 +268,7 @@ AllocEngine::AllocEngine(AllocType engine_type, uint64_t attempts,
         isc_throw(BadValue, "Invalid/unsupported allocation algorithm");
     }
 
-    // If this is IPv6 allocation engine, initalize also temporary addrs
+    // If this is IPv6 allocation engine, initialize also temporary addrs
     // and prefixes
     if (ipv6) {
         switch (engine_type) {
@@ -427,7 +427,7 @@ AllocEngine::allocateLeases6(ClientContext6& ctx) {
         //       assign new leases
         //
         // We could implement those checks as nested ifs, but the performance
-        // gain would be minimal and the code readibility loss would be substantial.
+        // gain would be minimal and the code readability loss would be substantial.
         // Hence independent checks.
 
         // Case 1: There are no leases and there's a reservation for this host.
@@ -1840,7 +1840,7 @@ AllocEngine::reclaimExpiredLease(const Lease4Ptr& lease,
     if (!skipped) {
 
         // Generate removal name change request for D2, if required.
-        // This will return immediatelly if the DNS wasn't updated
+        // This will return immediately if the DNS wasn't updated
         // when the lease was created.
         queueNCR(CHG_REMOVE, lease);
 

--- a/src/lib/dhcpsrv/alloc_engine.h
+++ b/src/lib/dhcpsrv/alloc_engine.h
@@ -411,7 +411,7 @@ public:
         bool isAllocated(const asiolink::IOAddress& prefix,
                          const uint8_t prefix_len = 128) const;
 
-        /// @brief Conveniece function adding host identifier into
+        /// @brief Convenience function adding host identifier into
         /// @ref host_identifiers_ list.
         ///
         /// @param id_type Identifier type.
@@ -475,7 +475,7 @@ public:
 
     /// @brief Allocates IPv6 leases for a given IA container
     ///
-    /// This method uses the currently selected allocator to pick allocatable
+    /// This method uses the currently selected allocator to pick allocable
     /// resources (i.e. addresses or prefixes) from specified subnet, creates
     /// a lease (one or more, if needed) for that resources and then inserts
     /// it into LeaseMgr (if this allocation is not fake, i.e. this is not a
@@ -593,9 +593,9 @@ public:
     ///   "expired-reclaimed" or removing it from the lease databse,
     /// - updating statistics of assigned and reclaimed leases
     ///
-    /// Note: declined leases fall under the same expiration/reclaimation
+    /// Note: declined leases fall under the same expiration/reclamation
     /// processing as normal leases. In principle, it would be more elegant
-    /// to have a separate processing for declined leases reclaimation. However,
+    /// to have a separate processing for declined leases reclamation. However,
     /// due to performance reasons we decided to use them together. Several
     /// aspects were taken into consideration. First, normal leases are expected
     /// to expire frequently, so in a typical deployment this method will have
@@ -617,7 +617,7 @@ public:
     /// entry, stats dump, hooks).
     ///
     /// @param max_leases Maximum number of leases to be reclaimed.
-    /// @param timeout Maximum amount of time that the reclaimation routine
+    /// @param timeout Maximum amount of time that the reclamation routine
     /// may be processing expired leases, expressed in milliseconds.
     /// @param remove_lease A boolean value indicating if the lease should
     /// be removed when it is reclaimed (if true) or it should be left in the
@@ -651,9 +651,9 @@ public:
     ///   "expired-reclaimed" or removing it from the lease databse,
     /// - updating statistics of assigned and reclaimed leases
     ///
-    /// Note: declined leases fall under the same expiration/reclaimation
+    /// Note: declined leases fall under the same expiration/reclamation
     /// processing as normal leases. In principle, it would be more elegant
-    /// to have a separate processing for declined leases reclaimation. However,
+    /// to have a separate processing for declined leases reclamation. However,
     /// due to performance reasons we decided to use them together. Several
     /// aspects were taken into consideration. First, normal leases are expected
     /// to expire frequently, so in a typical deployment this method will have
@@ -671,11 +671,11 @@ public:
     /// declined leases. They are always removed.
     ///
     /// Also, for declined leases @ref reclaimDeclinedLease4 is
-    /// called. It conductsseveral declined specific operation (extra log
+    /// called. It conducts several declined specific operation (extra log
     /// entry, stats dump, hooks).
     ///
     /// @param max_leases Maximum number of leases to be reclaimed.
-    /// @param timeout Maximum amount of time that the reclaimation routine
+    /// @param timeout Maximum amount of time that the reclamation routine
     /// may be processing expired leases, expressed in milliseconds.
     /// @param remove_lease A boolean value indicating if the lease should
     /// be removed when it is reclaimed (if true) or it should be left in the
@@ -964,7 +964,7 @@ private:
 
     /// @brief Marks lease as reclaimed in the database.
     ///
-    /// This method is called internally by the leases reclaimation routines.
+    /// This method is called internally by the leases reclamation routines.
     /// Depending on the value of the @c remove_lease parameter this method
     /// will delete the reclaimed lease from the database or set its sate
     /// to "expired-reclaimed". In the latter case it will also clear the
@@ -989,7 +989,8 @@ private:
     /// @anchor reclaimDeclinedLease4
     /// @brief Conducts steps necessary for reclaiming declined IPv4 lease.
     ///
-    /// These are the additional steps required when recoving a declined lease:
+    /// These are the additional steps required when recovering a declined
+    /// lease:
     /// - bump decline recovered stat
     /// - log lease recovery
     /// - call lease4_recover hook
@@ -1002,7 +1003,8 @@ private:
     /// @anchor reclaimDeclinedLease6
     /// @brief Conducts steps necessary for reclaiming declined IPv6 lease.
     ///
-    /// These are the additional steps required when recoving a declined lease:
+    /// These are the additional steps required when recovering a declined
+    /// lease:
     /// - bump decline recovered stat
     /// - log lease recovery
     /// - call lease6_recover hook
@@ -1092,7 +1094,7 @@ public:
         /// received by the server.
         IdentifierList host_identifiers_;
 
-        /// @brief Conveniece function adding host identifier into
+        /// @brief Convenience function adding host identifier into
         /// @ref host_identifiers_ list.
         ///
         /// @param id_type Identifier type.
@@ -1347,8 +1349,8 @@ private:
     /// - @ref ClientContext4::fake_allocation_ Is this real i.e. REQUEST (false)
     ///        or just picking an address for DISCOVER that is not really
     ///        allocated (true)
-    /// @return allocated lease (or NULL in the unlikely case of the lease just
-    ///        becomed unavailable)
+    /// @return allocated lease (or NULL in the unlikely case that the lease had
+    ///     just become unavailable)
     Lease4Ptr createLease4(const ClientContext4& ctx,
                            const isc::asiolink::IOAddress& addr);
 
@@ -1391,7 +1393,7 @@ private:
     /// the new lease.
     ///
     /// @param address Requested address for which the lease should be
-    /// allocted.
+    /// allocated.
     /// @param ctx Client context holding the data extracted from the
     /// client's message.
     ///

--- a/src/lib/dhcpsrv/base_host_data_source.h
+++ b/src/lib/dhcpsrv/base_host_data_source.h
@@ -60,7 +60,7 @@ public:
     /// @brief Specifies the type of an identifier.
     ///
     /// This is currently used only by MySQL host data source for now, but
-    /// it is envisagad that it will be used by other host data sources
+    /// it is envisaged that it will be used by other host data sources
     /// in the future. Also, this list will grow over time. It is likely
     /// that we'll implement other identifiers in the future, e.g. remote-id.
     ///
@@ -106,7 +106,7 @@ public:
     /// because a particular client may have reservations in multiple subnets.
     ///
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -130,7 +130,7 @@ public:
     /// @brief Returns a host connected to the IPv4 subnet.
     ///
     /// Implementations of this method should guard against the case when
-    /// mutliple instances of the @c Host are present, e.g. when two
+    /// multiple instances of the @c Host are present, e.g. when two
     /// @c Host objects are found, one for the DUID, another one for the
     /// HW address. In such case, an implementation of this method
     /// should throw an exception.
@@ -150,7 +150,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -185,7 +185,7 @@ public:
     /// @brief Returns a host connected to the IPv6 subnet.
     ///
     /// Implementations of this method should guard against the case when
-    /// mutliple instances of the @c Host are present, e.g. when two
+    /// multiple instances of the @c Host are present, e.g. when two
     /// @c Host objects are found, one for the DUID, another one for the
     /// HW address. In such case, an implementation of this method
     /// should throw an exception.
@@ -204,7 +204,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///

--- a/src/lib/dhcpsrv/cfg_expiration.cc
+++ b/src/lib/dhcpsrv/cfg_expiration.cc
@@ -94,7 +94,7 @@ CfgExpiration::rangeCheck(const int64_t value, const uint64_t max_value,
                           const std::string& config_parameter_name) const {
     if (value < 0) {
         isc_throw(OutOfRange, "value for configuration parameter '"
-                  << config_parameter_name << "' must not be negtive");
+                  << config_parameter_name << "' must not be negative");
 
     } else if (value > max_value) {
         isc_throw(OutOfRange, "out range value '" << value << "' for configuration"

--- a/src/lib/dhcpsrv/cfg_expiration.h
+++ b/src/lib/dhcpsrv/cfg_expiration.h
@@ -112,7 +112,7 @@ public:
     /// @brief Name of the timer for reclaiming expired leases.
     static const std::string RECLAIM_EXPIRED_TIMER_NAME;
 
-    /// @brief Name of the timer for flushing relclaimed leases.
+    /// @brief Name of the timer for flushing reclaimed leases.
     static const std::string FLUSH_RECLAIMED_TIMER_NAME;
 
     //@}

--- a/src/lib/dhcpsrv/cfg_hosts.h
+++ b/src/lib/dhcpsrv/cfg_hosts.h
@@ -77,7 +77,7 @@ public:
     /// because a particular client may have reservations in multiple subnets.
     ///
     /// @param identifier_type One of the supported identifier types.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -93,7 +93,7 @@ public:
     /// because a particular client may have reservations in multiple subnets.
     ///
     /// @param identifier_type One of the supported identifier types.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -181,7 +181,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -195,7 +195,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -249,7 +249,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -263,7 +263,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -340,7 +340,7 @@ private:
     /// @param identifier_type The type of the supplied identifier.
     /// @param identifier Pointer to a first byte of the identifier.
     /// @param identifier_len Length of the identifier.
-    /// @param [out] storage Container to which the retreived objects are
+    /// @param [out] storage Container to which the retrieved objects are
     /// appended.
     /// @tparam One of the @c ConstHostCollection of @c HostCollection.
     template<typename Storage>
@@ -421,7 +421,7 @@ private:
     /// @param subnet_id IPv4 or IPv6 subnet identifier.
     /// @param subnet6 A boolean flag which indicates if the subnet identifier
     /// points to a IPv4 (if false) or IPv6 subnet (if true).
-    /// @param identifier_type Indentifier type.
+    /// @param identifier_type Identifier type.
     /// @param identifier Pointer to a first byte of the buffer holding an
     /// identifier.
     /// @param identifier_len Identifier length.

--- a/src/lib/dhcpsrv/cfg_iface.h
+++ b/src/lib/dhcpsrv/cfg_iface.h
@@ -114,7 +114,7 @@ public:
 /// socket and bind to link local address as well as open a socket bound to
 /// the specified unicast address.
 ///
-/// The DHCPv4 configuration doesn't accept the simulatenous use of the
+/// The DHCPv4 configuration doesn't accept the simultaneous use of the
 /// "interface-name" and the "interface-name/address" tuple for the
 /// given interface. When the "interface-name" is specified it implies
 /// that the sockets will be opened on for all addresses configured on
@@ -177,11 +177,11 @@ public:
 
     /// @brief Select interface to be used to receive DHCP traffic.
     ///
-    /// @ref CfgIface for a detail explaination of the interface name argument.
+    /// @ref CfgIface for a detail explanation of the interface name argument.
     ///
     /// @param family Address family (AF_INET or AF_INET6).
     /// @param iface_name Explicit interface name, a wildcard name (*) of
-    /// the interface(s) or the pair of iterface/unicast-address to be used
+    /// the interface(s) or the pair of interface/unicast-address to be used
     /// to receive DHCP traffic.
     ///
     /// @throw InvalidIfaceName If the interface name is incorrect, e.g. empty.
@@ -258,7 +258,7 @@ private:
     ///
     /// This method is useful to check if the current configuration uses
     /// multiple IPv4 addresses on any interface. This is important when
-    /// using raw sockets to recieve messages from the clients because
+    /// using raw sockets to receive messages from the clients because
     /// each packet may be received multiple times when it is sent from
     /// a directly connected client. If this is the case, a warning must
     /// be logged.

--- a/src/lib/dhcpsrv/cfg_mac_source.h
+++ b/src/lib/dhcpsrv/cfg_mac_source.h
@@ -47,7 +47,7 @@ class CfgMACSource {
     static uint32_t MACSourceFromText(const std::string& name);
 
 
-    /// @brief Adds additional MAC/hardware address aquisition.
+    /// @brief Adds additional MAC/hardware address acquisition.
     ///
     /// @param source MAC source (see constants in Pkt::HWADDR_SOURCE_*)
     ///

--- a/src/lib/dhcpsrv/cfg_option_def.cc
+++ b/src/lib/dhcpsrv/cfg_option_def.cc
@@ -38,7 +38,7 @@ CfgOptionDef::equals(const CfgOptionDef& other) const {
     // Get option space names held by the other object.
     const std::list<std::string>&
         other_names = other.option_definitions_.getOptionSpaceNames();
-    // Compareg that sizes are the same. If they hold different number of
+    // Compare that sizes are the same. If they hold different number of
     // option space names the objects are not equal.
     if (names.size() != other_names.size()) {
         return (false);

--- a/src/lib/dhcpsrv/cfg_option_def.h
+++ b/src/lib/dhcpsrv/cfg_option_def.h
@@ -104,7 +104,7 @@ public:
 
     /// @brief Return option definition for the particular option space and name.
     ///
-    /// @param option_space pption space.
+    /// @param option_space option space.
     /// @param option_name option name.
     ///
     /// @return An option definition or NULL pointer if option definition

--- a/src/lib/dhcpsrv/cfg_subnets4.cc
+++ b/src/lib/dhcpsrv/cfg_subnets4.cc
@@ -85,7 +85,7 @@ CfgSubnets4::selectSubnet(const SubnetSelector& selector) const {
 
     // If relayed message has been received, try to match the giaddr with the
     // relay address specified for a subnet. It is also possible that the relay
-    // address will not match with any of the relay addresses accross all
+    // address will not match with any of the relay addresses across all
     // subnets, but we need to verify that for all subnets before we can try
     // to use the giaddr to match with the subnet prefix.
     if (!selector.giaddr_.isV4Zero()) {

--- a/src/lib/dhcpsrv/cfg_subnets4.h
+++ b/src/lib/dhcpsrv/cfg_subnets4.h
@@ -171,7 +171,7 @@ public:
     /// This method updates statistics that are affected by the newly committed
     /// configuration. In particular, it updates the number of available addresses
     /// in each subnet. Other statistics may be added in the future. In general,
-    /// these are statistics that are dependant only on configuration, so they are
+    /// these are statistics that are dependent only on configuration, so they are
     /// not expected to change until the next reconfiguration event.
     void updateStatistics();
 

--- a/src/lib/dhcpsrv/cfg_subnets6.h
+++ b/src/lib/dhcpsrv/cfg_subnets6.h
@@ -129,7 +129,7 @@ public:
     /// This method updates statistics that are affected by the newly committed
     /// configuration. In particular, it updates the number of available addresses
     /// and prefixes in each subnet. Other statistics may be added in the future. In
-    /// general, these are statistics that are dependant only on configuration, so
+    /// general, these are statistics that are dependent only on configuration, so
     /// they are not expected to change until the next reconfiguration event.
     void updateStatistics();
 

--- a/src/lib/dhcpsrv/cfgmgr.h
+++ b/src/lib/dhcpsrv/cfgmgr.h
@@ -120,7 +120,7 @@ public:
 
     /// @brief returns path do the data directory
     ///
-    /// This method returns a path to writeable directory that DHCP servers
+    /// This method returns a path to writable directory that DHCP servers
     /// can store data in.
     /// @return data directory
     std::string getDataDir() const;

--- a/src/lib/dhcpsrv/cql_lease_mgr.h
+++ b/src/lib/dhcpsrv/cql_lease_mgr.h
@@ -572,7 +572,7 @@ private:
     ///
     /// This method performs the common actions for the various getLease4()
     /// methods. It acts as an interface to the getLeaseCollection() method,
-    /// but retrieveing only a single lease.
+    /// but retrieving only a single lease.
     ///
     /// @param stindex Index of statement being executed
     /// @param data array containing input parameters for the query
@@ -584,7 +584,7 @@ private:
     ///
     /// This method performs the common actions for the various getLease4()
     /// methods. It acts as an interface to the getLeaseCollection() method,
-    /// but retrieveing only a single lease.
+    /// but retrieving only a single lease.
     ///
     /// @param stindex Index of statement being executed
     /// @param data array containing input parameters for the query

--- a/src/lib/dhcpsrv/d2_client_cfg.h
+++ b/src/lib/dhcpsrv/d2_client_cfg.h
@@ -49,7 +49,7 @@ public:
 class D2ClientConfig {
 public:
     /// @brief Default configuration constants.
-    /// @todo For now these are hard-coded as configuraiton layer cannot
+    /// @todo For now these are hard-coded as configuration layer cannot
     /// readily provide them (see Trac #3358).
     static const char* DFT_SERVER_IP;
     static const size_t DFT_SERVER_PORT;
@@ -147,7 +147,7 @@ public:
         return(sender_port_);
     }
 
-    /// @brief Return Maximun sender queue size
+    /// @brief Return Maximum sender queue size
     size_t getMaxQueueSize() const {
         return(max_queue_size_);
     }
@@ -214,7 +214,7 @@ public:
     ///
     /// @param mode_str text to convert to an enum.
     /// Valid string values: "never", "always", "when-present",
-    /// "when-not-present" (case insensistive)
+    /// "when-not-present" (case-insensitive)
     ///
     /// @return NameChangeFormat value which maps to the given string.
     ///
@@ -254,7 +254,7 @@ private:
     /// @brief IP port on which the client should send
     size_t sender_port_;
 
-    /// @brief Maxium number of NCRs allowed to queue waiting to send
+    /// @brief Maximum number of NCRs allowed to queue waiting to send
     size_t max_queue_size_;
 
     /// @brief The socket protocol to use with kea-dhcp-ddns.

--- a/src/lib/dhcpsrv/d2_client_mgr.h
+++ b/src/lib/dhcpsrv/d2_client_mgr.h
@@ -202,7 +202,7 @@ public:
     template <class T>
     void adjustFqdnFlags(const T& fqdn, T& fqdn_resp);
 
-    /// @brief Get direcional update flags based on server FQDN flags
+    /// @brief Get directional update flags based on server FQDN flags
     ///
     /// Templated convenience method which determines whether forward and
     /// reverse updates should be performed based on a server response version
@@ -213,9 +213,9 @@ public:
     /// * reverse will be true if N_FLAG is false
     ///
     /// @param fqdn_resp FQDN option from which to read server (outbound) flags
-    /// @param [out] forward bool value will be set to true if forward udpates
+    /// @param [out] forward bool value will be set to true if forward updates
     /// should be done, false if not.
-    /// @param [out] reverse bool value will be set to true if reverse udpates
+    /// @param [out] reverse bool value will be set to true if reverse updates
     /// should be done, false if not.
     /// @tparam T FQDN Option class containing the FQDN data such as
     /// dhcp::Option4ClientFqdn or dhcp::Option6ClientFqdn
@@ -258,7 +258,7 @@ public:
     /// @param io_service IOService to be used for sender IO event processing
     /// @warning It is up to the invoking layer to ensure the io_service
     /// instance used outlives the D2ClientMgr send mode. When the send mode
-    /// is exited, either expliclity by callind stopSender() or implicitly
+    /// is exited, either explicitly by callind stopSender() or implicitly
     /// through D2CLientMgr destruction, any ASIO objects such as sockets or
     /// timers will be closed and released.  If the io_service goes out of scope
     /// first this behavior could be unpredictable.

--- a/src/lib/dhcpsrv/daemon.h
+++ b/src/lib/dhcpsrv/daemon.h
@@ -35,7 +35,7 @@ public:
 /// implementations should derive from it.
 ///
 /// Methods are not pure virtual, as we need to instantiate basic daemons (e.g.
-/// Dhcpv6Srv) in tests, without going through the hassles of implemeting stub
+/// Dhcpv6Srv) in tests, without going through the hassles of implementing stub
 /// methods.
 ///
 /// Classes derived from @c Daemon may install custom signal handlers using
@@ -55,7 +55,7 @@ public:
     /// process to NULL.
     Daemon();
 
-    /// @brief Desctructor
+    /// @brief Destructor
     ///
     /// Having virtual destructor ensures that all derived classes will have
     /// virtual destructor as well.

--- a/src/lib/dhcpsrv/host.h
+++ b/src/lib/dhcpsrv/host.h
@@ -501,7 +501,7 @@ public:
     /// @brief Returns pointer to the DHCPv4 option data configuration for
     /// this host.
     ///
-    /// Returned pointer can be used to add, remove and udate options
+    /// Returned pointer can be used to add, remove and update options
     /// reserved for a host.
     CfgOptionPtr getCfgOption4() {
         return (cfg_option4_);
@@ -516,7 +516,7 @@ public:
     /// @brief Returns pointer to the DHCPv6 option data configuration for
     /// this host.
     ///
-    /// Returned pointer can be used to add, remove and udate options
+    /// Returned pointer can be used to add, remove and update options
     /// reserved for a host.
     CfgOptionPtr getCfgOption6() {
         return (cfg_option6_);

--- a/src/lib/dhcpsrv/host_container.h
+++ b/src/lib/dhcpsrv/host_container.h
@@ -64,7 +64,7 @@ typedef boost::multi_index_container<
         // Second index is used to search for the host using reserved IPv4
         // address.
         boost::multi_index::ordered_non_unique<
-            // Index using values returned by the @c Host::getIPv4Resrvation.
+            // Index using values returned by the @c Host::getIPv4Reservation.
             boost::multi_index::const_mem_fun<Host, const asiolink::IOAddress&,
                                                &Host::getIPv4Reservation>
         >

--- a/src/lib/dhcpsrv/host_mgr.h
+++ b/src/lib/dhcpsrv/host_mgr.h
@@ -117,7 +117,7 @@ public:
     /// reservations from the alternate source.
     ///
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -162,11 +162,11 @@ public:
     /// @brief Returns a host connected to the IPv4 subnet.
     ///
     /// This method returns a single reservation for a particular host as
-    /// documneted in the @c BaseHostDataSource::get4.
+    /// documented in the @c BaseHostDataSource::get4.
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -213,7 +213,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///

--- a/src/lib/dhcpsrv/lease.h
+++ b/src/lib/dhcpsrv/lease.h
@@ -37,7 +37,7 @@ struct Lease {
 
     /// @brief returns text representation of a lease type
     /// @param type lease or pool type to be converted
-    /// @return text decription
+    /// @return text description
     static std::string typeToText(Type type);
 
     /// @name Common lease states constants.
@@ -144,7 +144,7 @@ struct Lease {
     /// @brief Holds the lease state(s).
     ///
     /// This is the field that holds the lease state(s). Typically, a
-    /// lease remains in a single states. However, it is posible to
+    /// lease remains in a single states. However, it is possible to
     /// define a value for state which indicates that the lease remains
     /// in multiple logical states.
     ///
@@ -390,7 +390,7 @@ struct Lease4 : public Lease {
 
     /// @brief Convert lease to printable form
     ///
-    /// @return Textual represenation of lease data
+    /// @return Textual representation of lease data
     virtual std::string toText() const;
 
     /// @brief Sets IPv4 lease to declined state.
@@ -548,7 +548,7 @@ typedef std::vector<Lease6Ptr> Lease6Collection;
 /// Dumps the output of Lease::toText to the given stream.
 /// @param os output stream to which the output is
 /// @param lease reference to Lease object to dump
-/// @return a reference to the output stream paramater
+/// @return a reference to the output stream parameter
 std::ostream&
 operator<<(std::ostream& os, const Lease& lease);
 

--- a/src/lib/dhcpsrv/lease_file_loader.h
+++ b/src/lib/dhcpsrv/lease_file_loader.h
@@ -218,7 +218,7 @@ public:
     }
 };
 
-} // namesapce dhcp
-} // namespace isc
+}  // namespace dhcp
+}  // namespace isc
 
 #endif // LEASE_FILE_LOADER_H

--- a/src/lib/dhcpsrv/lease_file_stats.h
+++ b/src/lib/dhcpsrv/lease_file_stats.h
@@ -88,7 +88,7 @@ protected:
     uint32_t write_errs_;
 };
 
-} // namespace isc::dhcp
-} // namesapce isc
+}  // namespace dhcp
+}  // namespace isc
 
 #endif // LEASE_FILE_STATS_H

--- a/src/lib/dhcpsrv/logging_info.cc
+++ b/src/lib/dhcpsrv/logging_info.cc
@@ -89,7 +89,7 @@ LoggingInfo::toSpec() const {
 
     LoggerSpecification spec(name_, severity_, debuglevel_);
 
-    // Go over logger destinations and create output options accordinly.
+    // Go over logger destinations and create output options accordingly.
     for (std::vector<LoggingDestination>::const_iterator dest =
              destinations_.begin(); dest != destinations_.end(); ++dest) {
 

--- a/src/lib/dhcpsrv/memfile_lease_mgr.cc
+++ b/src/lib/dhcpsrv/memfile_lease_mgr.cc
@@ -50,7 +50,7 @@ namespace dhcp {
 /// the interval timer and assigns a callback function (pointer to which is
 /// passed in the constructor), which will be called at the specified
 /// intervals to perform the cleanup. It is also responsible for creating
-/// and maintaing the object which is used to spawn the new process which
+/// and maintaining the object which is used to spawn the new process which
 /// executes the @c kea-lfc program.
 ///
 /// This functionality is enclosed in a separate class so as the implementation
@@ -216,7 +216,7 @@ LFCSetup::setup(const uint32_t lfc_interval,
         callback_();
     }
 
-    // If it's suposed to run periodically, setup that now.
+    // If it's supposed to run periodically, setup that now.
     if (lfc_interval > 0) {
         // Set the timer to call callback function periodically.
         LOG_INFO(dhcpsrv_logger, DHCPSRV_MEMFILE_LFC_SETUP).arg(lfc_interval);
@@ -332,7 +332,7 @@ public:
     /// The result set is populated by iterating over the IPv4 leases in
     /// storage, in ascending order by address, accumulating the lease state
     /// counts per subnet. Note that walking the leases by address should
-    /// inherently group them by subnet, and while this does not gaurantee
+    /// inherently group them by subnet, and while this does not guarantee
     /// ascending order of subnet id, it should be sufficient to accumulate
     /// state counts per subnet.  This avoids introducing an additional
     /// subnet_id index.
@@ -425,7 +425,7 @@ public:
     /// The result set is populated by iterating over the IPv6 leases in
     /// storage, in ascending order by address, accumulating the lease state
     /// counts per subnet. Note that walking the leases by address should
-    /// inherently group them by subnet, and while this does not gaurantee
+    /// inherently group them by subnet, and while this does not guarantee
     /// ascending order of subnet id, it should be sufficient to accumulate
     /// state counts per subnet.  This avoids introducing an additional
     /// subnet_id index.
@@ -993,12 +993,12 @@ Memfile_LeaseMgr::deleteExpiredReclaimedLeases(const uint32_t secs,
 
     // This returns the first element which is greater than the specified
     // tuple (true, time(NULL) - secs). However, the range between the
-    // beginnng of the index and returned element also includes all the
+    // beginning of the index and returned element also includes all the
     // elements for which the first value is false (lease state is NOT
     // reclaimed), because false < true. All elements between the
     // beginning of the index and the element returned, for which the
     // first value is true, represent the reclaimed leases which should
-    // be deleted, because their expiration time + secs has occured earlier
+    // be deleted, because their expiration time + secs has occurred earlier
     // than current time.
     typename IndexType::const_iterator upper_limit =
         index.upper_bound(boost::make_tuple(true, time(NULL) - secs));

--- a/src/lib/dhcpsrv/memfile_lease_mgr.h
+++ b/src/lib/dhcpsrv/memfile_lease_mgr.h
@@ -650,7 +650,7 @@ private:
     /// the unit tests need to override this path (with the path in the
     /// Kea build directory, the @c KEA_LFC_EXECUTABLE environmental
     /// variable should be set to hold an absolute path to the kea-lfc
-    /// excutable.
+    /// executable.
     /// @param conversion_needed flag that indicates input lease file(s) are
     /// schema do not match the current schema (older or newer), and need
     /// conversion. This value is passed through to LFCSetup::setup() via its

--- a/src/lib/dhcpsrv/memfile_lease_storage.h
+++ b/src/lib/dhcpsrv/memfile_lease_storage.h
@@ -232,7 +232,7 @@ typedef Lease6Storage::index<ExpirationIndexTag>::type Lease6StorageExpirationIn
 /// @brief DHCPv4 lease storage index by address.
 typedef Lease4Storage::index<AddressIndexTag>::type Lease4StorageAddressIndex;
 
-/// @brief DHCPv4 lease storage index by exiration time.
+/// @brief DHCPv4 lease storage index by expiration time.
 typedef Lease4Storage::index<ExpirationIndexTag>::type Lease4StorageExpirationIndex;
 
 /// @brief DHCPv4 lease storage index by HW address and subnet identifier.

--- a/src/lib/dhcpsrv/mysql_connection.cc
+++ b/src/lib/dhcpsrv/mysql_connection.cc
@@ -115,7 +115,7 @@ MySqlConnection::openDatabase() {
         }
 
         // The timeout is only valid if greater than zero, as depending on the
-        // database, a zero timeout might signify someting like "wait
+        // database, a zero timeout might signify something like "wait
         // indefinitely".
         //
         // The check below also rejects a value greater than the maximum

--- a/src/lib/dhcpsrv/mysql_host_data_source.cc
+++ b/src/lib/dhcpsrv/mysql_host_data_source.cc
@@ -1184,7 +1184,7 @@ private:
 /// host information, DHCPv4 options, DHCPv6 options and IPv6 reservations.
 ///
 /// This class extends the @ref MySqlHostWithOptionsExchange class with the
-/// mechanisms to retrieve IPv6 reservations. This class is used in sitations
+/// mechanisms to retrieve IPv6 reservations. This class is used in situations
 /// when it is desired to retrieve DHCPv6 specific information about the host
 /// (DHCPv6 options and reservations), or entire information about the host
 /// (DHCPv4 options, DHCPv6 options and reservations). The following are the
@@ -1747,7 +1747,7 @@ public:
     /// @brief Statement Tags
     ///
     /// The contents of the enum are indexes into the list of SQL statements.
-    /// It is assumed that the order is such that the indicies of statements
+    /// It is assumed that the order is such that the indices of statements
     /// reading the database are less than those of statements modifying the
     /// database.
     enum StatementIndex {
@@ -1862,7 +1862,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     /// @param stindex Statement index.

--- a/src/lib/dhcpsrv/mysql_host_data_source.h
+++ b/src/lib/dhcpsrv/mysql_host_data_source.h
@@ -86,7 +86,7 @@ public:
     /// because a particular client may have reservations in multiple subnets.
     ///
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -109,7 +109,7 @@ public:
     /// @brief Returns a host connected to the IPv4 subnet.
     ///
     /// Implementations of this method should guard against the case when
-    /// mutliple instances of the @c Host are present, e.g. when two
+    /// multiple instances of the @c Host are present, e.g. when two
     /// @c Host objects are found, one for the DUID, another one for the
     /// HW address. In such case, an implementation of this method
     /// should throw an MultipleRecords exception.
@@ -128,7 +128,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -160,7 +160,7 @@ public:
     /// @brief Returns a host connected to the IPv6 subnet.
     ///
     /// Implementations of this method should guard against the case when
-    /// mutliple instances of the @c Host are present, e.g. when two
+    /// multiple instances of the @c Host are present, e.g. when two
     /// @c Host objects are found, one for the DUID, another one for the
     /// HW address. In such case, an implementation of this method
     /// should throw an MultipleRecords exception.
@@ -179,7 +179,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///

--- a/src/lib/dhcpsrv/mysql_lease_mgr.cc
+++ b/src/lib/dhcpsrv/mysql_lease_mgr.cc
@@ -46,7 +46,7 @@ using namespace std;
 /// - data being retrieved from the database (as in getting lease information)
 /// - selection criteria used to determine which records to update/retrieve.
 ///
-/// All such data is associated with the prepared statment using an array of
+/// All such data is associated with the prepared statement using an array of
 /// MYSQL_BIND structures.  Each element in the array corresponds to one
 /// parameter in the prepared statement - the first element in the array is
 /// associated with the first parameter, the second element with the second
@@ -71,7 +71,7 @@ using namespace std;
 ///   lease object.
 
 namespace {
-    
+
 /// @brief Maximum length of the hostname stored in DNS.
 ///
 /// This length is restricted by the length of the domain-name carried
@@ -226,7 +226,7 @@ namespace dhcp {
 /// @brief Common MySQL and Lease Data Methods
 ///
 /// The MySqlLease4Exchange and MySqlLease6Exchange classes provide the
-/// functionaility to set up binding information between variables in the
+/// functionality to set up binding information between variables in the
 /// program and data extracted from the database.  This class is the common
 /// base to both of them, containing some common methods.
 
@@ -752,7 +752,7 @@ public:
             // is guaranteed to be valid until the next non-const operation on
             // addr6_.)
             //
-            // The const_cast could be avoided by copying the string to a writeable
+            // The const_cast could be avoided by copying the string to a writable
             // buffer and storing the address of that in the "buffer" element.
             // However, this introduces a copy operation (with additional overhead)
             // purely to get round the structures introduced by design of the
@@ -1227,7 +1227,7 @@ private:
 ///
 /// This class is used to recalculate lease statistics for MySQL
 /// lease storage.  It does so by executing a query which returns a result
-/// containining contain one row per monitored state per lease type per
+/// containing one row per monitored state per lease type per
 /// subnet, ordered by subnet id in ascending order.
 ///
 class MySqlLeaseStatsQuery : public LeaseStatsQuery {
@@ -1549,7 +1549,7 @@ void MySqlLeaseMgr::getLeaseCollection(StatementIndex stindex,
 void MySqlLeaseMgr::getLease(StatementIndex stindex, MYSQL_BIND* bind,
                              Lease4Ptr& result) const {
     // Create appropriate collection object and get all leases matching
-    // the selection criteria.  The "single" paraeter is true to indicate
+    // the selection criteria.  The "single" parameter is true to indicate
     // that the called method should throw an exception if multiple
     // matching records are found: this particular method is called when only
     // one or zero matches is expected.
@@ -1568,7 +1568,7 @@ void MySqlLeaseMgr::getLease(StatementIndex stindex, MYSQL_BIND* bind,
 void MySqlLeaseMgr::getLease(StatementIndex stindex, MYSQL_BIND* bind,
                              Lease6Ptr& result) const {
     // Create appropriate collection object and get all leases matching
-    // the selection criteria.  The "single" paraeter is true to indicate
+    // the selection criteria.  The "single" parameter is true to indicate
     // that the called method should throw an exception if multiple
     // matching records are found: this particular method is called when only
     // one or zero matches is expected.
@@ -1786,7 +1786,7 @@ MySqlLeaseMgr::getLeases6(Lease::Type lease_type,
     // the "const" is discarded before the uint8_t* is cast to char*.
     //
     // Note that the const_cast could be avoided by copying the DUID to
-    // a writeable buffer and storing the address of that in the "buffer"
+    // a writable buffer and storing the address of that in the "buffer"
     // element.  However, this introduces a copy operation (with additional
     // overhead) purely to get round the structures introduced by design of
     // the MySQL interface (which uses the area pointed to by "buffer" as

--- a/src/lib/dhcpsrv/mysql_lease_mgr.h
+++ b/src/lib/dhcpsrv/mysql_lease_mgr.h
@@ -409,8 +409,8 @@ public:
         INSERT_LEASE6,               // Add entry to lease6 table
         UPDATE_LEASE4,               // Update a Lease4 entry
         UPDATE_LEASE6,               // Update a Lease6 entry
-        RECOUNT_LEASE4_STATS,        // Fetches IPv4 address statisics
-        RECOUNT_LEASE6_STATS,        // Fetches IPv6 address statisics
+        RECOUNT_LEASE4_STATS,        // Fetches IPv4 address statistics
+        RECOUNT_LEASE6_STATS,        // Fetches IPv6 address statistics
         NUM_STATEMENTS               // Number of statements
     };
 
@@ -421,7 +421,7 @@ private:
     /// of the addLease method.  It binds the contents of the lease object to
     /// the prepared statement and adds it to the database.
     ///
-    /// @param stindex Index of statemnent being executed
+    /// @param stindex Index of statement being executed
     /// @param bind MYSQL_BIND array that has been created for the type
     ///        of lease in question.
     ///
@@ -502,7 +502,7 @@ private:
     ///
     /// This method performs the common actions for the various getLease4()
     /// methods.  It acts as an interface to the getLeaseCollection() method,
-    /// but retrieveing only a single lease.
+    /// but retrieving only a single lease.
     ///
     /// @param stindex Index of statement being executed
     /// @param bind MYSQL_BIND array for input parameters
@@ -514,7 +514,7 @@ private:
     ///
     /// This method performs the common actions for the various getLease46)
     /// methods.  It acts as an interface to the getLeaseCollection() method,
-    /// but retrieveing only a single lease.
+    /// but retrieving only a single lease.
     ///
     /// @param stindex Index of statement being executed
     /// @param bind MYSQL_BIND array for input parameters

--- a/src/lib/dhcpsrv/parsers/client_class_def_parser.h
+++ b/src/lib/dhcpsrv/parsers/client_class_def_parser.h
@@ -22,7 +22,7 @@
 /// There parsers defined are:
 ///
 /// ClientClassDefListParser  - creates a ClientClassDictionary from a list
-/// of element maps, where each map contains the entries that specifiy a
+/// of element maps, where each map contains the entries that specify a
 /// single class.  The names of the classes in the are expected to be
 /// unique.  Attempting to define a duplicate class will result in an
 /// DhcpConfigError throw.  Invoking @c commit() method causes the dictionary
@@ -59,7 +59,7 @@ public:
     /// accept string as first argument.
     /// @param expression variable in which to store the new expression
     /// @param global_context is a pointer to the global context which
-    /// stores global scope parameters, options, option defintions.
+    /// stores global scope parameters, options, option definitions.
     ExpressionParser(const std::string& dummy, ExpressionPtr& expression,
                      ParserContextPtr global_context);
 
@@ -98,7 +98,7 @@ public:
     /// accept string as first argument.
     /// @param class_dictionary dictionary into which the class should be added
     /// @param global_context is a pointer to the global context which
-    /// stores global scope parameters, options, option defintions.
+    /// stores global scope parameters, options, option definitions.
     ClientClassDefParser(const std::string& dummy,
                          ClientClassDictionaryPtr& class_dictionary,
                          ParserContextPtr global_context);
@@ -150,7 +150,7 @@ public:
     /// @param dummy first argument is ignored, all Parser constructors
     /// accept string as first argument.
     /// @param global_context is a pointer to the global context which
-    /// stores global scope parameters, options, option defintions.
+    /// stores global scope parameters, options, option definitions.
     ClientClassDefListParser(const std::string& dummy,
                         ParserContextPtr global_context);
 

--- a/src/lib/dhcpsrv/parsers/dbaccess_parser.cc
+++ b/src/lib/dhcpsrv/parsers/dbaccess_parser.cc
@@ -96,7 +96,7 @@ DbAccessParser::build(isc::data::ConstElementPtr config_value) {
                   << " (" << config_value->getPosition() << ")");
     }
 
-    // c. Check that the lfc-interval is a number and it is within a resonable
+    // c. Check that the lfc-interval is a number and it is within a reasonable
     // range.
     if ((lfc_interval < 0) || (lfc_interval > std::numeric_limits<uint32_t>::max())) {
         isc_throw(BadValue, "lfc-interval value: " << lfc_interval
@@ -104,7 +104,7 @@ DbAccessParser::build(isc::data::ConstElementPtr config_value) {
                   << std::numeric_limits<uint32_t>::max());
     }
 
-    // d. Check that the timeout is a number and it is within a resonable
+    // d. Check that the timeout is a number and it is within a reasonable
     // range.
     if ((timeout < 0) || (timeout > std::numeric_limits<uint32_t>::max())) {
         isc_throw(BadValue, "timeout value: " << timeout

--- a/src/lib/dhcpsrv/parsers/dhcp_parsers.cc
+++ b/src/lib/dhcpsrv/parsers/dhcp_parsers.cc
@@ -671,7 +671,7 @@ OptionDataParser::createOption(ConstElementPtr option_data) {
 
     OptionPtr option;
     if (!def) {
-        // @todo We have a limited set of option definitions initalized at
+        // @todo We have a limited set of option definitions initialized at
         // the moment.  In the future we want to initialize option definitions
         // for all options.  Consequently an error will be issued if an option
         // definition does not exist for a particular option code. For now it is
@@ -1028,7 +1028,7 @@ void PoolsListParser::commit() {
 
     if (pools_) {
         // local_pools_ holds the values produced by the build function.
-        // At this point parsing should have completed successfuly so
+        // At this point parsing should have completed successfully so
         // we can append new data to the supplied storage.
         pools_->insert(pools_->end(), local_pools_->begin(), local_pools_->end());
     }
@@ -1156,7 +1156,7 @@ void
 PoolParser::commit() {
     if (pools_) {
         // local_pools_ holds the values produced by the build function.
-        // At this point parsing should have completed successfuly so
+        // At this point parsing should have completed successfully so
         // we can append new data to the supplied storage.
         pools_->insert(pools_->end(), local_pools_.begin(), local_pools_.end());
     }
@@ -1548,7 +1548,7 @@ D2ClientConfigParser::commit() {
     // rollback.  This gets sticky, because who owns the listener instance?
     // Does CfgMgr maintain it or does the server class?  If the latter
     // how do we get that value here?
-    // I'm thinkikng D2ClientConfig could contain the listener instance
+    // I'm thinking D2ClientConfig could contain the listener instance
     CfgMgr::instance().setD2ClientConfig(local_client_config_);
 }
 

--- a/src/lib/dhcpsrv/parsers/dhcp_parsers.h
+++ b/src/lib/dhcpsrv/parsers/dhcp_parsers.h
@@ -57,7 +57,7 @@ public:
     /// otherwise its data value and the position will be updated with the
     /// given values.
     ///
-    /// @param name is the name of the paramater to store.
+    /// @param name is the name of the parameter to store.
     /// @param value is the data value to store.
     /// @param position is the position of the data element within a
     /// configuration string (file).
@@ -73,7 +73,7 @@ public:
     /// @param name is the name of the parameter for which the data
     /// value is desired.
     ///
-    /// @return The paramater's data value of type @c ValueType.
+    /// @return The parameter's data value of type @c ValueType.
     /// @throw DhcpConfigError if the parameter is not found.
     ValueType getParam(const std::string& name) const {
         typename std::map<std::string, ValueType>::const_iterator param
@@ -122,7 +122,7 @@ public:
     /// value is desired.
     /// @param default_value value to use the default
     ///
-    /// @return The paramater's data value of type @c ValueType.
+    /// @return The parameter's data value of type @c ValueType.
     ValueType getOptionalParam(const std::string& name,
                                const ValueType& default_value) const {
         typename std::map<std::string, ValueType>::const_iterator param
@@ -140,7 +140,7 @@ public:
     /// Deletes the entry for the given parameter from the store if it
     /// exists.
     ///
-    /// @param name is the name of the paramater to delete.
+    /// @param name is the name of the parameter to delete.
     void delParam(const std::string& name) {
         values_.erase(name);
         positions_.erase(name);
@@ -248,7 +248,7 @@ typedef boost::shared_ptr<ParserContext> ParserContextPtr;
 /// possible values. It provides a common constructor, commit, and templated
 /// data storage.  The "build" method implementation must be provided by a
 /// declaring type.
-/// @param ValueType is the data type of the configuration paramater value
+/// @param ValueType is the data type of the configuration parameter value
 /// the parser should handle.
 template<typename ValueType>
 class ValueParser : public DhcpConfigParser {
@@ -364,10 +364,10 @@ private:
 
 };
 
-/// @brief parser for MAC/hardware aquisition sources
+/// @brief parser for MAC/hardware acquisition sources
 ///
 /// This parser handles Dhcp6/mac-sources entry.
-/// It contains a list of MAC/hardware aquisition source, i.e. methods how
+/// It contains a list of MAC/hardware acquisition source, i.e. methods how
 /// MAC address can possibly by obtained in DHCPv6. For a currently supported
 /// methods, see @ref isc::dhcp::Pkt::getMAC.
 class MACSourcesListConfigParser : public DhcpConfigParser {
@@ -571,8 +571,8 @@ private:
 
     /// @brief Finds an option definition within an option space
     ///
-    /// Given an option space and an option code, find the correpsonding
-    /// option defintion within the option defintion storage.
+    /// Given an option space and an option code, find the corresponding
+    /// option definition within the option definition storage.
     ///
     /// @param option_space name of the parameter option space
     /// @param search_key an option code or name to be used to lookup the
@@ -580,7 +580,7 @@ private:
     /// @tparam A numeric type for searching using an option code or the
     /// string for searching using the option name.
     ///
-    /// @return OptionDefintionPtr of the option defintion or an
+    /// @return OptionDefintionPtr of the option definition or an
     /// empty OptionDefinitionPtr if not found.
     /// @throw DhcpConfigError if the option space requested is not valid
     /// for this server.
@@ -595,7 +595,7 @@ private:
     /// are invalid or insufficient this function emits an exception.
     ///
     /// @warning this function does not check if options_ storage pointer
-    /// is intitialized but this check is not needed here because it is done
+    /// is initialized but this check is not needed here because it is done
     /// in the \ref build function.
     ///
     /// @param option_data An element holding data for a single option being
@@ -732,7 +732,7 @@ public:
     /// @param dummy first argument is ignored, all Parser constructors
     /// accept string as first argument.
     /// @param global_context is a pointer to the global context which
-    /// stores global scope parameters, options, option defintions.
+    /// stores global scope parameters, options, option definitions.
     OptionDefParser(const std::string& dummy, ParserContextPtr global_context);
 
     /// @brief Parses an entry that describes single option definition.
@@ -786,7 +786,7 @@ public:
     /// @param dummy first argument is ignored, all Parser constructors
     /// accept string as first argument.
     /// @param global_context is a pointer to the global context which
-    /// stores global scope parameters, options, option defintions.
+    /// stores global scope parameters, options, option definitions.
     OptionDefListParser(const std::string& dummy,
                         ParserContextPtr global_context);
 
@@ -946,7 +946,7 @@ protected:
 
 /// @brief parser for additional relay information
 ///
-/// This concrete parser handles RelayInfo structure defintions.
+/// This concrete parser handles RelayInfo structure definitions.
 /// So far that structure holds only relay IP (v4 or v6) address, but it
 /// is expected that the number of parameters will increase over time.
 ///

--- a/src/lib/dhcpsrv/parsers/host_reservation_parser.cc
+++ b/src/lib/dhcpsrv/parsers/host_reservation_parser.cc
@@ -290,7 +290,7 @@ HostReservationParser6::build(isc::data::ConstElementPtr reservation_data) {
 
                         // Convert the prefix length from the string to the
                         // number. Note, that we don't use the uint8_t type
-                        // as the lexical cast would expect a chracter, e.g.
+                        // as the lexical cast would expect a character, e.g.
                         // 'a', instead of prefix length, e.g. '64'.
                         try {
                             prefix_len = boost::lexical_cast<

--- a/src/lib/dhcpsrv/parsers/host_reservation_parser.h
+++ b/src/lib/dhcpsrv/parsers/host_reservation_parser.h
@@ -149,7 +149,7 @@ protected:
 /// @brief Parser for a list of host identifiers.
 ///
 /// This is a parent parser class for parsing "host-reservation-identifiers"
-/// global configuration parmeter. The DHCPv4 and DHCPv6 specific parsers
+/// global configuration parameter. The DHCPv4 and DHCPv6 specific parsers
 /// derive from this class.
 class HostReservationIdsParser : public DhcpConfigParser {
 public:

--- a/src/lib/dhcpsrv/pgsql_connection.cc
+++ b/src/lib/dhcpsrv/pgsql_connection.cc
@@ -19,7 +19,7 @@
 // #define ERRCODE_UNIQUE_VIOLATION MAKE_SQLSTATE('2','3','5','0','5')
 //
 // PostgreSQL deliberately omits the MAKE_SQLSTATE macro so callers can/must
-// supply their own.  We'll define it as an initlizer_list:
+// supply their own.  We'll define it as an initialization list:
 #define MAKE_SQLSTATE(ch1,ch2,ch3,ch4,ch5) {ch1,ch2,ch3,ch4,ch5}
 // So we can use it like this: const char some_error[] = ERRCODE_xxxx;
 #define PGSQL_STATECODE_LEN 5
@@ -35,7 +35,7 @@ const int PGSQL_DEFAULT_CONNECTION_TIMEOUT = 5; // seconds
 
 const char PgSqlConnection::DUPLICATE_KEY[] = ERRCODE_UNIQUE_VIOLATION;
 
-PgSqlResult::PgSqlResult(PGresult *result) 
+PgSqlResult::PgSqlResult(PGresult *result)
     : result_(result), rows_(0), cols_(0) {
     if (!result) {
         isc_throw (BadValue, "PgSqlResult result pointer cannot be null");
@@ -45,10 +45,10 @@ PgSqlResult::PgSqlResult(PGresult *result)
     cols_ = PQnfields(result);
 }
 
-void 
+void
 PgSqlResult::rowCheck(int row) const {
     if (row < 0 || row >= rows_) {
-        isc_throw (DbOperationError, "row: " << row 
+        isc_throw (DbOperationError, "row: " << row
                    << ", out of range: 0.." << rows_);
     }
 }
@@ -198,7 +198,7 @@ PgSqlConnection::openDatabase() {
         }
 
         // The timeout is only valid if greater than zero, as depending on the
-        // database, a zero timeout might signify someting like "wait
+        // database, a zero timeout might signify something like "wait
         // indefinitely".
         //
         // The check below also rejects a value greater than the maximum
@@ -239,7 +239,7 @@ PgSqlConnection::openDatabase() {
 bool
 PgSqlConnection::compareError(const PgSqlResult& r, const char* error_state) {
     const char* sqlstate = PQresultErrorField(r, PG_DIAG_SQLSTATE);
-    // PostgreSQL garuantees it will always be 5 characters long
+    // PostgreSQL guarantees it will always be 5 characters long
     return ((sqlstate != NULL) &&
             (memcmp(sqlstate, error_state, PGSQL_STATECODE_LEN) == 0));
 }

--- a/src/lib/dhcpsrv/pgsql_connection.h
+++ b/src/lib/dhcpsrv/pgsql_connection.h
@@ -60,7 +60,7 @@ const size_t OID_TIMESTAMP = 1114;
 
 //@}
 
-/// @brief RAII wrapper for Posgtresql Result sets
+/// @brief RAII wrapper for PostgreSQL Result sets
 ///
 /// When a Postgresql statement is executed, the results are returned
 /// in pointer allocated structure, PGresult*. Data and status information

--- a/src/lib/dhcpsrv/pgsql_exchange.cc
+++ b/src/lib/dhcpsrv/pgsql_exchange.cc
@@ -57,8 +57,8 @@ void PsqlBindArray::add(const bool& value)  {
 }
 
 void PsqlBindArray::add(const uint8_t& byte) {
-    // We static_cast to an unsigned int, otherwise lexcial_cast may to
-    // treat byte as a character, which yields "" for unprintable values 
+    // We static_cast to an unsigned int, otherwise lexical_cast may to
+    // treat byte as a character, which yields "" for unprintable values
     addTempString(boost::lexical_cast<std::string>
                               (static_cast<unsigned int>(byte)));
 }
@@ -168,8 +168,8 @@ PgSqlExchange::getRawColumnValue(const PgSqlResult& r, const int row,
     return (value);
 }
 
-bool 
-PgSqlExchange::isColumnNull(const PgSqlResult& r, const int row, 
+bool
+PgSqlExchange::isColumnNull(const PgSqlResult& r, const int row,
                             const size_t col) {
     r.rowColCheck(row,col);
     return (PQgetisnull(r, row, col));
@@ -261,7 +261,7 @@ PgSqlExchange::getColumnLabel(const PgSqlResult& r, const size_t column) {
     return (r.getColumnLabel(column));
 }
 
-std::string 
+std::string
 PgSqlExchange::dumpRow(const PgSqlResult& r, int row) {
     r.rowCheck(row);
     std::ostringstream stream;
@@ -269,7 +269,7 @@ PgSqlExchange::dumpRow(const PgSqlResult& r, int row) {
     for (int col = 0; col < columns; ++col) {
         const char* val = getRawColumnValue(r, row, col);
         std::string name = r.getColumnLabel(col);
-        int format = PQfformat(r, col); 
+        int format = PQfformat(r, col);
 
         stream << col << "   " << name << " : " ;
         if (format == PsqlBindArray::TEXT_FMT) {

--- a/src/lib/dhcpsrv/pgsql_host_data_source.cc
+++ b/src/lib/dhcpsrv/pgsql_host_data_source.cc
@@ -91,7 +91,7 @@ public:
         : PgSqlExchange(HOST_COLUMNS + additional_columns_num) {
         // Set the column names for use by this class. This only comprises
         // names used by the PgSqlHostExchange class. Derived classes will
-        // need to set names for the columns they use.  Currenty these are
+        // need to set names for the columns they use.  Currently these are
         // only used for logging purposes.
         columns_[HOST_ID_COL] = "host_id";
         columns_[DHCP_IDENTIFIER_COL] = "dhcp_identifier";
@@ -418,7 +418,7 @@ private:
           most_recent_option_id_(0) {
         }
 
-        /// @brief Reintializes state information
+        /// @brief Reinitializes state information
         ///
         /// This function should be called prior to processing a fetched
         /// set of options.
@@ -689,8 +689,8 @@ public:
     ///
     /// The fetched row includes both host information and DHCP option
     /// information. Because the SELECT queries use one or more LEFT JOIN
-    /// clauses, the result set may contain duplicated host or options 
-    /// entries. This method detects duplicated information and discards such 
+    /// clauses, the result set may contain duplicated host or options
+    /// entries. This method detects duplicated information and discards such
     /// entries.
     ///
     /// @param [out] hosts Container holding parsed hosts and options.
@@ -901,7 +901,7 @@ public:
                       " IPv6 reservation");
         }
 
-        // If we have reservation id we havent' seen yet, retrive the
+        // If we have reservation id we havent' seen yet, retrieve the
         // the reservation, adding it to the current host
         uint64_t reservation_id = getReservationId(r, row);
         if (reservation_id && (reservation_id > most_recent_reservation_id_)) {
@@ -1164,7 +1164,7 @@ public:
     /// @brief Statement Tags
     ///
     /// The contents of the enum are indexes into the list of SQL statements.
-    /// It is assumed that the order is such that the indicies of statements
+    /// It is assumed that the order is such that the indices of statements
     /// reading the database are less than those of statements modifying the
     /// database.
     enum StatementIndex {
@@ -1277,7 +1277,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     /// @param stindex Statement index.
@@ -1517,7 +1517,7 @@ TaggedStatementArray tagged_statements = { {
 
     // PgSqlHostDataSourceImpl::INSERT_HOST
     // Inserts a host into the 'hosts' table. Returns the inserted host id.
-    {11, 
+    {11,
      { OID_BYTEA, OID_INT2,
        OID_INT4, OID_INT4, OID_INT8, OID_VARCHAR,
        OID_VARCHAR, OID_VARCHAR },

--- a/src/lib/dhcpsrv/pgsql_host_data_source.h
+++ b/src/lib/dhcpsrv/pgsql_host_data_source.h
@@ -96,7 +96,7 @@ public:
     /// because a particular client may have reservations in multiple subnets.
     ///
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -119,7 +119,7 @@ public:
     /// @brief Returns a host connected to the IPv4 subnet.
     ///
     /// Implementations of this method should guard against the case when
-    /// mutliple instances of the @c Host are present, e.g. when two
+    /// multiple instances of the @c Host are present, e.g. when two
     /// @c Host objects are found, one for the DUID, another one for the
     /// HW address. In such case, an implementation of this method
     /// should throw an MultipleRecords exception.
@@ -138,7 +138,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -168,7 +168,7 @@ public:
     /// @brief Returns a host connected to the IPv6 subnet.
     ///
     /// Implementations of this method should guard against the case when
-    /// mutliple instances of the @c Host are present, e.g. when two
+    /// multiple instances of the @c Host are present, e.g. when two
     /// @c Host objects are found, one for the DUID, another one for the
     /// HW address. In such case, an implementation of this method
     /// should throw an MultipleRecords exception.
@@ -187,7 +187,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -221,7 +221,7 @@ public:
     /// The method will insert the given host and all of its children (v4
     /// options, v6 options, and v6 reservations) into the database.  It
     /// relies on constraints defined as part of the PostgreSQL schema to
-    /// defend against duplicate entries and to ensure referential 
+    /// defend against duplicate entries and to ensure referential
     /// integrity.
     ///
     /// Violation of any of these constraints for a host will result in a
@@ -232,7 +232,7 @@ public:
     /// -# DHCP ID, DHCP ID TYPE, and DHCP4_SUBNET_ID combination must be unique
     /// -# DHCP ID, DHCP ID TYPE, and DHCP6_SUBNET_ID combination must be unique
     ///
-    /// In addition, violating the following referential contraints will
+    /// In addition, violating the following referential constraints will
     /// a DbOperationError exception:
     ///
     /// -# DHCP ID TYPE must be defined in the HOST_IDENTIFIER_TYPE table

--- a/src/lib/dhcpsrv/pgsql_lease_mgr.cc
+++ b/src/lib/dhcpsrv/pgsql_lease_mgr.cc
@@ -26,8 +26,8 @@ using namespace std;
 
 namespace {
 
-/// @todo TKM lease6 needs to accomodate hwaddr,hwtype, and hwaddr source
-/// columns.  This is coverd by tickets #3557, #4530, and PR#9.
+/// @todo TKM lease6 needs to accommodate hwaddr,hwtype, and hwaddr source
+/// columns.  This is covered by tickets #3557, #4530, and PR#9.
 
 /// @brief Catalog of all the SQL statements currently supported.  Note
 /// that the order columns appear in statement body must match the order they
@@ -705,7 +705,7 @@ private:
 
 /// @brief Base PgSql derivation of the statistical lease data query
 ///
-/// This class provides the functionality such as results storgae and row
+/// This class provides the functionality such as results storage and row
 /// fetching common to fulfilling the statistical lease data query.
 ///
 class PgSqlLeaseStatsQuery : public LeaseStatsQuery {
@@ -822,9 +822,11 @@ PgSqlLeaseMgr::PgSqlLeaseMgr(const DatabaseConnection::ParameterMap& parameters)
     pair<uint32_t, uint32_t> code_version(PG_CURRENT_VERSION, PG_CURRENT_MINOR);
     pair<uint32_t, uint32_t> db_version = getVersion();
     if (code_version != db_version) {
-        isc_throw(DbOpenError, "Posgresql schema version mismatch: need version: "
-                  << code_version.first << "." << code_version.second
-                  << " found version:  " << db_version.first << "." << db_version.second);
+        isc_throw(DbOpenError,
+                  "PostgreSQL schema version mismatch: need version: "
+                      << code_version.first << "." << code_version.second
+                      << " found version:  " << db_version.first << "."
+                      << db_version.second);
     }
 }
 

--- a/src/lib/dhcpsrv/pgsql_lease_mgr.h
+++ b/src/lib/dhcpsrv/pgsql_lease_mgr.h
@@ -499,7 +499,7 @@ private:
     ///
     /// This method performs the common actions for the various getLease4()
     /// methods.  It acts as an interface to the getLeaseCollection() method,
-    /// but retrieveing only a single lease.
+    /// but retrieving only a single lease.
     ///
     /// @param stindex Index of statement being executed
     /// @param bind_array array containing input parameters for the query
@@ -511,7 +511,7 @@ private:
     ///
     /// This method performs the common actions for the various getLease4()
     /// methods.  It acts as an interface to the getLeaseCollection() method,
-    /// but retrieveing only a single lease.
+    /// but retrieving only a single lease.
     ///
     /// @param stindex Index of statement being executed
     /// @param bind_array array containing input parameters for the query

--- a/src/lib/dhcpsrv/pool.cc
+++ b/src/lib/dhcpsrv/pool.cc
@@ -170,7 +170,7 @@ Pool6::Pool6(const asiolink::IOAddress& prefix, const uint8_t prefix_len,
         }
 
         /// @todo Check that the prefixes actually match. Theoretically, a
-        /// user could specify a prefix which sets insgnificant bits. We should
+        /// user could specify a prefix which sets insignificant bits. We should
         /// clear insignificant bits based on the prefix length but this
         /// should be considered a part of the IOAddress class, perhaps and
         /// requires a bit of work (mainly in terms of testing).

--- a/src/lib/dhcpsrv/srv_config.h
+++ b/src/lib/dhcpsrv/srv_config.h
@@ -109,7 +109,7 @@ public:
     /// @return true if sequence numbers are equal.
     bool sequenceEquals(const SrvConfig& other);
 
-    /// @name Modifiers and accesors for the configuration objects.
+    /// @name Modifiers and accessors for the configuration objects.
     ///
     /// @warning References to the objects returned by accessors are only
     /// valid during the lifetime of the @c SrvConfig object which
@@ -364,7 +364,7 @@ public:
         class_dictionary_ = dictionary;
     }
 
-    /// @brief Copies the currnet configuration to a new configuration.
+    /// @brief Copies the current configuration to a new configuration.
     ///
     /// This method copies the parameters stored in the configuration to
     /// an object passed as parameter. The configuration sequence is not
@@ -376,7 +376,7 @@ public:
     /// the default copy constructors can't be used. Implementing this
     /// requires quite a lot of time so this is left as is for now.
     /// The lack of ability to copy the entire configuration makes
-    /// revert function of the @c CfgMgr unsuable.
+    /// the revert function of the @c CfgMgr unusable.
     ///
     /// @param [out] new_config An object to which the configuration will
     /// be copied.
@@ -481,7 +481,7 @@ public:
 
     /// @brief Returns DHCP4o6 IPC port
     ///
-    /// See @ref setDhcp4o6Port or brief discussion.                         
+    /// See @ref setDhcp4o6Port or brief discussion.
     /// @return value of DHCP4o6 IPC port
     uint32_t getDhcp4o6Port() {
         return (dhcp4o6_port_);

--- a/src/lib/dhcpsrv/subnet.h
+++ b/src/lib/dhcpsrv/subnet.h
@@ -357,7 +357,7 @@ protected:
     /// @param t2 T2 (rebind-time) timer, expressed in seconds
     /// @param valid_lifetime valid lifetime of leases in this subnet (in seconds)
     /// @param relay optional relay information (currently with address only)
-    /// @param id arbitraty subnet id, value of 0 triggers autogeneration
+    /// @param id arbitrary subnet id, value of 0 triggers autogeneration
     /// of subnet id
     Subnet(const isc::asiolink::IOAddress& prefix, uint8_t len,
            const Triplet<uint32_t>& t1,
@@ -374,7 +374,7 @@ protected:
 
     /// @brief keeps the subnet-id value
     ///
-    /// It is inreased every time a new Subnet object is created. It is reset
+    /// It is incremented every time a new Subnet object is created. It is reset
     /// (@ref resetSubnetID) every time reconfiguration
     /// occurs.
     ///
@@ -521,7 +521,7 @@ public:
     /// @param t1 renewal timer (in seconds)
     /// @param t2 rebind timer (in seconds)
     /// @param valid_lifetime preferred lifetime of leases (in seconds)
-    /// @param id arbitraty subnet id, default value of 0 triggers
+    /// @param id arbitrary subnet id, default value of 0 triggers
     /// autogeneration of subnet id
     Subnet4(const isc::asiolink::IOAddress& prefix, uint8_t length,
             const Triplet<uint32_t>& t1,
@@ -620,7 +620,7 @@ public:
     /// @param t2 rebind timer (in seconds)
     /// @param preferred_lifetime preferred lifetime of leases (in seconds)
     /// @param valid_lifetime preferred lifetime of leases (in seconds)
-    /// @param id arbitraty subnet id, default value of 0 triggers
+    /// @param id arbitrary subnet id, default value of 0 triggers
     /// autogeneration of subnet id
     Subnet6(const isc::asiolink::IOAddress& prefix, uint8_t length,
             const Triplet<uint32_t>& t1,
@@ -629,7 +629,7 @@ public:
             const Triplet<uint32_t>& valid_lifetime,
             const SubnetID id = 0);
 
-    /// @brief Returns preverred lifetime (in seconds)
+    /// @brief Returns preferred lifetime (in seconds)
     ///
     /// @return a triplet with preferred lifetime
     Triplet<uint32_t> getPreferred() const {

--- a/src/lib/dhcpsrv/tests/alloc_engine4_unittest.cc
+++ b/src/lib/dhcpsrv/tests/alloc_engine4_unittest.cc
@@ -512,7 +512,7 @@ TEST_F(AllocEngine4Test, requestReuseExpiredLease4) {
     Lease4Ptr lease(new Lease4(addr, hwaddr2, clientid2, sizeof(clientid2),
                                sizeof(hwaddr2), 495, 100, 200, now,
                                subnet_->getID()));
-    // Make a copy of the lease, so as we can comapre that with the old lease
+    // Make a copy of the lease, so as we can compare that with the old lease
     // instance returned by the allocation engine.
     Lease4 original_lease(*lease);
 
@@ -714,7 +714,7 @@ TEST_F(AllocEngine4Test, requestReuseDeclinedLease4Stats) {
     testStatistics(stat2, 1001);
 }
 
-// This test checks that the Allocation Engine correcly identifies the
+// This test checks that the Allocation Engine correctly identifies the
 // existing client's lease in the lease database, using the client
 // identifier and HW address.
 TEST_F(AllocEngine4Test, identifyClientLease) {
@@ -1652,8 +1652,7 @@ TEST_F(AllocEngine4Test, findReservation) {
     ctx.addHostIdentifier(Host::IDENT_HWADDR, hwaddr_->hwaddr_);
     ctx.addHostIdentifier(Host::IDENT_DUID, clientid_->getDuid());
 
-    // There is no reservation in the database so no host should be
-    // retruned.
+    // There is no reservation in the database so no host should be returned.
     ASSERT_NO_THROW(engine.findReservation(ctx));
     EXPECT_FALSE(ctx.host_);
 

--- a/src/lib/dhcpsrv/tests/alloc_engine6_unittest.cc
+++ b/src/lib/dhcpsrv/tests/alloc_engine6_unittest.cc
@@ -1320,7 +1320,7 @@ TEST_F(AllocEngine6Test, reservedAddressRenewal) {
 /// reservation for the second IA. This works for Requests and Renews, though.
 /// In both of those messages, when processing of the first IA is complete,
 /// we have a lease in the database. Based on that, when processing the second
-/// IA we can detect that the first reservated address is in use already and
+/// IA we can detect that the first reserved address is in use already and
 /// use the second reservation.
 TEST_F(AllocEngine6Test, DISABLED_reserved2AddressesSolicit) {
     // Create reservation for the client. This is in-pool reservation,
@@ -1667,7 +1667,7 @@ TEST_F(AllocEngine6Test, largeAllocationAttemptsOverride) {
         address << "2001:db8:1::";
         address << i;
 
-        // Allocate the leease.
+        // Allocate the lease.
         Lease6Ptr lease(new Lease6(Lease::TYPE_NA, IOAddress(address.str()),
                                    duid, iaid, 501, 502, 503, 504, subnet_->getID(),
                                    HWAddrPtr(), 0));

--- a/src/lib/dhcpsrv/tests/alloc_engine_expiration_unittest.cc
+++ b/src/lib/dhcpsrv/tests/alloc_engine_expiration_unittest.cc
@@ -48,7 +48,7 @@ const unsigned int TEST_LEASES_NUM = 100;
 struct LowerBound {
     /// @brief Constructor.
     ///
-    /// @param lower_bound Interger value wrapped by the structure.
+    /// @param lower_bound Integer value wrapped by the structure.
     explicit LowerBound(const size_t lower_bound)
         : lower_bound_(lower_bound) { };
 
@@ -70,7 +70,7 @@ struct LowerBound {
 struct UpperBound {
     /// @brief Constructor.
     ///
-    /// @param lower_bound Interger value wrapped by the structure.
+    /// @param lower_bound Integer value wrapped by the structure.
     explicit UpperBound(const size_t upper_bound)
         : upper_bound_(upper_bound) { };
 
@@ -98,7 +98,7 @@ std::string callout_argument_name("lease4");
 /// - it processes multiple leases,
 /// - leases are processed in certain order,
 /// - number of processed leases may be limited by the parameters,
-/// - maxium duration of the lease reclamation routine may be limited,
+/// - maximum duration of the lease reclamation routine may be limited,
 /// - reclaimed leases may be marked as reclaimed or deleted,
 /// - DNS records for some of the leases must be removed when the lease
 ///   is reclaimed and DNS updates are enabled,
@@ -304,7 +304,7 @@ public:
     /// @brief Wrapper method running lease reclamation routine.
     ///
     /// @param max_leases Maximum number of leases to be reclaimed.
-    /// @param timeout Maximum amount of time that the reclaimation routine
+    /// @param timeout Maximum amount of time that the reclamation routine
     /// may be processing expired leases, expressed in seconds.
     /// @param remove_lease A boolean value indicating if the lease should
     /// be removed when it is reclaimed (if true) or it should be left in the
@@ -783,7 +783,7 @@ public:
                 << "check failed for i = " << i;
 
 
-            // At early stages of iterations, there should be conitnuous
+            // At early stages of iterations, there should be continuous
             // group of leases (expired and not expired) which haven't been
             // reclaimed.
             if (reclaimed_lower_bound > 0) {
@@ -838,7 +838,7 @@ public:
         EXPECT_TRUE(testLeases(&dnsUpdateGeneratedForLease, &oddLeaseIndex));
     }
 
-    /// @brief This test verfies that callouts are executed for each expired
+    /// @brief This test verifies that callouts are executed for each expired
     /// lease when installed.
     void testReclaimExpiredLeasesHooks() {
         for (unsigned int i = 0; i < TEST_LEASES_NUM; ++i) {
@@ -868,7 +868,7 @@ public:
         EXPECT_TRUE(testLeases(&leaseNotReclaimed, &oddLeaseIndex));
     }
 
-    /// @brief This test verfies that callouts are executed for each expired
+    /// @brief This test verifies that callouts are executed for each expired
     /// lease and that the lease is not reclaimed when skip flag is set.
     void testReclaimExpiredLeasesHooksWithSkip() {
         for (unsigned int i = 0; i < TEST_LEASES_NUM; ++i) {
@@ -1000,11 +1000,11 @@ public:
     ///
     /// This method works for both v4 and v6. Just make sure the correct
     /// statistic name is passed. This is the name of the assigned addresses,
-    /// that is expected to be decreased once the reclaimation procedure
+    /// that is expected to be decreased once the reclamation procedure
     /// is complete.
     ///
     /// @param stat_name name of the statistic for assigned addresses statistic
-    ///        ("assgined-addresses" for both v4 and "assigned-nas" for v6)
+    ///        ("assigned-addresses" for both v4 and "assigned-nas" for v6)
     void testReclaimDeclinedStats(const std::string& stat_name) {
 
         // Leases by default all belong to subnet_id_ = 1. Let's count the
@@ -1072,8 +1072,8 @@ public:
 
         // subnet[X].assigned-addresses should go down. Between the time
         // of DHCPDECLINE(v4)/DECLINE(v6) reception and declined expired lease
-        // reclaimation, we count this address as assigned-addresses. We decrease
-        // assigned-addresses(v4)/assgined-nas(v6) when we reclaim the lease,
+        // reclamation, we count this address as assigned-addresses. We decrease
+        // assigned-addresses(v4)/assigned-nas(v6) when we reclaim the lease,
         // not when the packet is received. For explanation, see Duplicate
         // Addresses (DHCPDECLINE support) (v4) or Duplicate Addresses (DECLINE
         // support) sections in the User's Guide or a comment in
@@ -1164,7 +1164,7 @@ public:
     /// @brief Wrapper method running lease reclamation routine.
     ///
     /// @param max_leases Maximum number of leases to be reclaimed.
-    /// @param timeout Maximum amount of time that the reclaimation routine
+    /// @param timeout Maximum amount of time that the reclamation routine
     /// may be processing expired leases, expressed in seconds.
     /// @param remove_lease A boolean value indicating if the lease should
     /// be removed when it is reclaimed (if true) or it should be left in the
@@ -1707,7 +1707,7 @@ public:
     /// @brief Wrapper method running lease reclamation routine.
     ///
     /// @param max_leases Maximum number of leases to be reclaimed.
-    /// @param timeout Maximum amount of time that the reclaimation routine
+    /// @param timeout Maximum amount of time that the reclamation routine
     /// may be processing expired leases, expressed in seconds.
     /// @param remove_lease A boolean value indicating if the lease should
     /// be removed when it is reclaimed (if true) or it should be left in the

--- a/src/lib/dhcpsrv/tests/alloc_engine_hooks_unittest.cc
+++ b/src/lib/dhcpsrv/tests/alloc_engine_hooks_unittest.cc
@@ -112,7 +112,7 @@ public:
     static bool callback_qry_options_copy_;
 };
 
-// For some reason intialization within a class makes the linker confused.
+// For some reason initialization within a class makes the linker confused.
 // linker complains about undefined references if they are defined within
 // the class declaration.
 const IOAddress HookAllocEngine6Test::addr_override_("2001:db8::abcd");
@@ -192,7 +192,7 @@ TEST_F(HookAllocEngine6Test, lease6_select) {
     EXPECT_FALSE(callback_fake_allocation_);
 
     // Check if all expected parameters are reported.  The order needs to be
-    // alphapbetical to match the order returned by
+    // alphabetical to match the order returned by
     // CallbackHandle::getAgrumentNames()
     vector<string> expected_argument_names;
     expected_argument_names.push_back("fake_allocation");
@@ -358,7 +358,7 @@ public:
     static bool callback_qry_options_copy_;
 };
 
-// For some reason intialization within a class makes the linker confused.
+// For some reason initialization within a class makes the linker confused.
 // linker complains about undefined references if they are defined within
 // the class declaration.
 const IOAddress HookAllocEngine4Test::addr_override_("192.0.3.1");
@@ -440,7 +440,7 @@ TEST_F(HookAllocEngine4Test, lease4_select) {
     EXPECT_EQ(callback_fake_allocation_, false);
 
     // Check if all expected parameters are reported.  The order needs to be
-    // alphapbetical to match the order returned by
+    // alphabetical to match the order returned by
     // CallbackHandle::getAgrumentNames()
     vector<string> expected_argument_names;
     expected_argument_names.push_back("fake_allocation");

--- a/src/lib/dhcpsrv/tests/alloc_engine_utils.h
+++ b/src/lib/dhcpsrv/tests/alloc_engine_utils.h
@@ -67,7 +67,7 @@ public:
     public:
 
         /// @brief constructor
-        /// @param type pool types that will be interated
+        /// @param type pool types that will be iterated through
         NakedIterativeAllocator(Lease::Type type)
             :IterativeAllocator(type) {
         }

--- a/src/lib/dhcpsrv/tests/callout_handle_store_unittest.cc
+++ b/src/lib/dhcpsrv/tests/callout_handle_store_unittest.cc
@@ -73,7 +73,7 @@ TEST(CalloutHandleStoreTest, StoreRetrieve) {
     EXPECT_FALSE(chptr_1 == chptr_2);
 
     // Check reference counts.  The getCalloutHandle function should be storing
-    // pointers to the objects poiunted to by chptr_2 and pktptr_2.
+    // pointers to the objects pointed to by chptr_2 and pktptr_2.
     EXPECT_EQ(1, chptr_1.use_count());
     EXPECT_EQ(1, pktptr_1.use_count());
     EXPECT_EQ(2, chptr_2.use_count());

--- a/src/lib/dhcpsrv/tests/cfg_expiration_unittest.cc
+++ b/src/lib/dhcpsrv/tests/cfg_expiration_unittest.cc
@@ -163,14 +163,14 @@ TEST(CfgExpirationTest, getUnwarnedReclaimCycles) {
 /// but instead they record the number of calls to them and the parameters
 /// with which they were executed. This allows for checking if the
 /// @c CfgExpiration object calls the leases reclamation routine with the
-/// appropriate parameteres.
+/// appropriate parameters.
 class LeaseReclamationStub {
 public:
 
     /// @brief Collection of parameters with which the @c reclaimExpiredLeases
     /// method is called.
     ///
-    /// Examination of these values allows for assesment if the @c CfgExpiration
+    /// Examination of these values allows for assessment if the @c CfgExpiration
     /// calls the routine with the appropriate values.
     struct RecordedParams {
         /// @brief Maximum number of leases to be processed.
@@ -233,7 +233,7 @@ public:
     /// expired-reclaimed leases.
     ///
     /// @param secs Specifies the minimum amount of time, expressed in
-    /// seconds, that must elapse before the expired-reclaime lease is
+    /// seconds, that must elapse before the expired-reclaimed lease is
     /// deleted from the database.
     void
     deleteReclaimedLeases(const uint32_t secs) {
@@ -401,7 +401,7 @@ TEST_F(CfgExpirationTimersTest, noLeaseAffinity) {
     EXPECT_EQ(0, stub_->delete_calls_count_);
 }
 
-// This test verfies that lease reclamation may be disabled.
+// This test verifies that lease reclamation may be disabled.
 TEST_F(CfgExpirationTimersTest, noLeaseReclamation) {
     // Disable both timers.
     cfg_.setReclaimTimerWaitTime(0);

--- a/src/lib/dhcpsrv/tests/cfg_host_operations_unittest.cc
+++ b/src/lib/dhcpsrv/tests/cfg_host_operations_unittest.cc
@@ -81,7 +81,7 @@ TEST(CfgHostOperationsTest, addIdentifier) {
     EXPECT_TRUE(cfg.getIdentifierTypes().empty());
 }
 
-// This test verfies that the default DHCPv4 configuration is created
+// This test verifies that the default DHCPv4 configuration is created
 // as expected.
 TEST(CfgHostOperationsTest, createConfig4) {
     CfgHostOperationsPtr cfg = CfgHostOperations::createConfig4();
@@ -91,7 +91,7 @@ TEST(CfgHostOperationsTest, createConfig4) {
     EXPECT_TRUE(identifierAtPosition(*cfg, Host::IDENT_CIRCUIT_ID, 2));
 }
 
-// This test verfies that the default DHCPv6 configuration is created
+// This test verifies that the default DHCPv6 configuration is created
 // as expected.
 TEST(CfgHostOperationsTest, createConfig6) {
     CfgHostOperationsPtr cfg = CfgHostOperations::createConfig6();

--- a/src/lib/dhcpsrv/tests/cfg_iface_unittest.cc
+++ b/src/lib/dhcpsrv/tests/cfg_iface_unittest.cc
@@ -342,7 +342,7 @@ TEST_F(CfgIfaceTest, equality) {
     EXPECT_FALSE(cfg1 == cfg2);
     EXPECT_TRUE(cfg1 != cfg2);
 
-    // Finally, both are equal as they use wildacard.
+    // Finally, both are equal as they use wildcard.
     cfg2.use(AF_INET, "*");
     EXPECT_TRUE(cfg1 == cfg2);
     EXPECT_FALSE(cfg1 != cfg2);

--- a/src/lib/dhcpsrv/tests/cfg_option_unittest.cc
+++ b/src/lib/dhcpsrv/tests/cfg_option_unittest.cc
@@ -452,7 +452,7 @@ TEST_F(CfgOptionTest, addNonUniqueOptions) {
                   OptionContainerTypeIndex::const_iterator> range =
             idx.equal_range(code);
         // Distance between iterators indicates how many options
-        // have been retured for the particular code.
+        // have been returned for the particular code.
         ASSERT_EQ(2, distance(range.first, range.second));
         // Check that returned options actually have the expected option code.
         for (OptionContainerTypeIndex::const_iterator option_desc = range.first;

--- a/src/lib/dhcpsrv/tests/cfg_rsoo_unittest.cc
+++ b/src/lib/dhcpsrv/tests/cfg_rsoo_unittest.cc
@@ -64,7 +64,7 @@ TEST(CfgRSOOTest, enableAndClear) {
     }
 }
 
-// This test verfies that the same option may be specified
+// This test verifies that the same option may be specified
 // multiple times and that the code doesn't fail.
 TEST(CfgRSOOTest, enableTwice) {
     CfgRSOO rsoo;

--- a/src/lib/dhcpsrv/tests/cfg_subnets6_unittest.cc
+++ b/src/lib/dhcpsrv/tests/cfg_subnets6_unittest.cc
@@ -240,7 +240,7 @@ TEST(CfgSubnets6Test, selectSubnetByRelayAddressAndClassify) {
     EXPECT_FALSE(cfg.selectSubnet(selector));
 }
 
-// Test that client classes are considered when the subnet is selcted by the
+// Test that client classes are considered when the subnet is selected by the
 // interface name.
 TEST(CfgSubnets6Test, selectSubnetByInterfaceNameAndClaassify) {
     CfgSubnets6 cfg;

--- a/src/lib/dhcpsrv/tests/client_class_def_parser_unittest.cc
+++ b/src/lib/dhcpsrv/tests/client_class_def_parser_unittest.cc
@@ -89,7 +89,7 @@ protected:
 
     /// @brief Convenience method for parsing a configuration
     ///
-    /// Attempt to parse a given client class defintion.
+    /// Attempt to parse a given client class definition.
     ///
     /// @param config - JSON string containing the client class configuration
     /// to parse.
@@ -101,7 +101,7 @@ protected:
     /// or by the parsing itself are not caught
     ClientClassDefPtr parseClientClassDef(const std::string& config,
                                           Option::Universe universe) {
-        // Create local dicitonary to which the parser add the class.
+        // Create local dictionary to which the parser add the class.
         ClientClassDictionaryPtr dictionary(new ClientClassDictionary());
         // Create the "global" context for the parser.
         ParserContextPtr context(new ParserContext(universe));
@@ -132,14 +132,14 @@ protected:
     /// @brief Convenience method for parsing a list of client class
     /// definitions.
     ///
-    /// Attempt to parse a given list of client class defintions into a
+    /// Attempt to parse a given list of client class definitions into a
     /// ClientClassDictionary.
     ///
     /// @param config - JSON string containing the list of definitions to parse.
     /// @param universe - the universe in which the parsing context should
     /// occur.
     /// @return Returns a pointer to class dictionary created
-    /// @throw indirectly, execptions convertring the JSON text to elements,
+    /// @throw indirectly, exceptions convertring the JSON text to elements,
     /// or by the parsing itself are not caught
     ClientClassDictionaryPtr parseClientClassDefList(const std::string& config,
                                                      Option::Universe universe)
@@ -157,7 +157,7 @@ protected:
         // Commit should push it to CfgMgr staging
         parser.commit();
 
-        // Return the parser's local dicationary
+        // Return the parser's local dictionary
         return (parser.local_dictionary_);
     }
 };
@@ -536,7 +536,7 @@ TEST_F(ClientClassDefListParserTest, simpleValidList) {
     ASSERT_TRUE(cclass);
     EXPECT_EQ("three", cclass->getName());
 
-    // For good measure, make sure we can't find a non-existant class.
+    // For good measure, make sure we can't find a non-existing class.
     ASSERT_NO_THROW(cclass = dictionary->findClass("bogus"));
     EXPECT_FALSE(cclass);
 

--- a/src/lib/dhcpsrv/tests/client_class_def_unittest.cc
+++ b/src/lib/dhcpsrv/tests/client_class_def_unittest.cc
@@ -222,7 +222,7 @@ TEST(ClientClassDictionary, basics) {
     // Verify duplicate add attempt throws
     ASSERT_THROW(dictionary->addClass(cclass), DuplicateClientClassDef);
 
-    // Verify that you cannot add emtpy class pointer
+    // Verify that you cannot add empty class pointer
     cclass.reset();
     ASSERT_THROW(dictionary->addClass(cclass), BadValue);
 
@@ -242,7 +242,7 @@ TEST(ClientClassDictionary, basics) {
     ASSERT_TRUE(cclass);
     EXPECT_EQ("cc3", cclass->getName());
 
-    // Verify the looking for non-existant returns empty pointer
+    // Verify the looking for non-existing returns empty pointer
     ASSERT_NO_THROW(cclass = dictionary->findClass("bogus"));
     EXPECT_FALSE(cclass);
 
@@ -254,7 +254,7 @@ TEST(ClientClassDictionary, basics) {
     ASSERT_NO_THROW(cclass = dictionary->findClass("cc3"));
     EXPECT_FALSE(cclass);
 
-    // Verify that we can attempt to remove a non-existant class
+    // Verify that we can attempt to remove a non-existing class
     // without harm.
     ASSERT_NO_THROW(dictionary->removeClass("cc3"));
     EXPECT_EQ(2, classes->size());

--- a/src/lib/dhcpsrv/tests/d2_client_unittest.cc
+++ b/src/lib/dhcpsrv/tests/d2_client_unittest.cc
@@ -769,7 +769,7 @@ TEST(D2ClientMgr, adjustDomainNameV4) {
     ASSERT_EQ(D2ClientConfig::RCM_NEVER, cfg->getReplaceClientNameMode());
 
     // replace-client-name is false, client passes in empty fqdn
-    // reponse domain should be empty/partial.
+    // response domain should be empty/partial.
     request.reset(new Option4ClientFqdn(0, Option4ClientFqdn::RCODE_CLIENT(),
                                         "", Option4ClientFqdn::PARTIAL));
     response.reset(new Option4ClientFqdn(*request));
@@ -812,7 +812,7 @@ TEST(D2ClientMgr, adjustDomainNameV4) {
     ASSERT_EQ(D2ClientConfig::RCM_WHEN_PRESENT, cfg->getReplaceClientNameMode());
 
     // replace-client-name is true, client passes in empty fqdn
-    // reponse domain should be empty/partial.
+    // response domain should be empty/partial.
     request.reset(new Option4ClientFqdn(0, Option4ClientFqdn::RCODE_CLIENT(),
                                         "", Option4ClientFqdn::PARTIAL));
     response.reset(new Option4ClientFqdn(*request));
@@ -822,7 +822,7 @@ TEST(D2ClientMgr, adjustDomainNameV4) {
     EXPECT_EQ(Option4ClientFqdn::PARTIAL, response->getDomainNameType());
 
     // replace-client-name is true, client passes in a partial fqdn
-    // reponse domain should be empty/partial.
+    // response domain should be empty/partial.
     request.reset(new Option4ClientFqdn(0, Option4ClientFqdn::RCODE_CLIENT(),
                                         "myhost", Option4ClientFqdn::PARTIAL));
     response.reset(new Option4ClientFqdn(*request));
@@ -833,7 +833,7 @@ TEST(D2ClientMgr, adjustDomainNameV4) {
 
 
     // replace-client-name is true, client passes in a full fqdn
-    // reponse domain should be empty/partial.
+    // response domain should be empty/partial.
     request.reset(new Option4ClientFqdn(0, Option4ClientFqdn::RCODE_CLIENT(),
                                         "myhost.example.com.",
                                          Option4ClientFqdn::FULL));
@@ -862,7 +862,7 @@ TEST(D2ClientMgr, adjustDomainNameV6) {
     ASSERT_EQ(D2ClientConfig::RCM_NEVER, cfg->getReplaceClientNameMode());
 
     // replace-client-name is false, client passes in empty fqdn
-    // reponse domain should be empty/partial.
+    // response domain should be empty/partial.
     request.reset(new Option6ClientFqdn(0, "", Option6ClientFqdn::PARTIAL));
     response.reset(new Option6ClientFqdn(*request));
 
@@ -902,7 +902,7 @@ TEST(D2ClientMgr, adjustDomainNameV6) {
     ASSERT_EQ(D2ClientConfig::RCM_WHEN_PRESENT, cfg->getReplaceClientNameMode());
 
     // replace-client-name is true, client passes in empty fqdn
-    // reponse domain should be empty/partial.
+    // response domain should be empty/partial.
     request.reset(new Option6ClientFqdn(0, "", Option6ClientFqdn::PARTIAL));
     response.reset(new Option6ClientFqdn(*request));
 
@@ -911,7 +911,7 @@ TEST(D2ClientMgr, adjustDomainNameV6) {
     EXPECT_EQ(Option6ClientFqdn::PARTIAL, response->getDomainNameType());
 
     // replace-client-name is true, client passes in a partial fqdn
-    // reponse domain should be empty/partial.
+    // response domain should be empty/partial.
     request.reset(new Option6ClientFqdn(0, "myhost",
                                         Option6ClientFqdn::PARTIAL));
     response.reset(new Option6ClientFqdn(*request));
@@ -922,7 +922,7 @@ TEST(D2ClientMgr, adjustDomainNameV6) {
 
 
     // replace-client-name is true, client passes in a full fqdn
-    // reponse domain should be empty/partial.
+    // response domain should be empty/partial.
     request.reset(new Option6ClientFqdn(0, "myhost.example.com.",
                                         Option6ClientFqdn::FULL));
     response.reset(new Option6ClientFqdn(*request));

--- a/src/lib/dhcpsrv/tests/d2_udp_unittest.cc
+++ b/src/lib/dhcpsrv/tests/d2_udp_unittest.cc
@@ -28,7 +28,7 @@ using namespace isc;
 namespace {
 
 /// @brief Test fixture for excerising D2ClientMgr send management
-/// services.  It inherents from D2ClientMgr to allow overriding various
+/// services.  It inherits from D2ClientMgr to allow overriding various
 /// methods and accessing otherwise restricted member.  In particular it
 /// overrides the NameChangeSender completion completion callback, allowing
 /// the injection of send errors.
@@ -128,10 +128,10 @@ public:
     /// @brief Overrides base class completion callback.
     ///
     /// This method will be invoked each time a send completes. It allows
-    /// intervention prior to calling the production implemenation in the
+    /// intervention prior to calling the production implementation in the
     /// base.  If simulate_send_failure_ is true, the base call impl will
     /// be called with an error status, otherwise it will be called with
-    /// the result paramater given.
+    /// the result parameter given.
     ///
     /// @param result Result code of the send operation.
     /// @param ncr NameChangeRequest which failed to send.
@@ -170,7 +170,7 @@ public:
         return (boost::bind(&D2ClientMgrTest::error_handler, this, _1, _2));
     }
 
-    /// @brief Contructs a NameChangeRequest message from a fixed JSON string.
+    /// @brief Constructs a NameChangeRequest message from a fixed JSON string.
     dhcp_ddns::NameChangeRequestPtr buildTestNcr() {
         // Build an NCR from json string.
         const char* ncr_str =
@@ -483,7 +483,7 @@ TEST_F(D2ClientMgrTest, udpSuspendUpdates) {
     EXPECT_FALSE(amSending());
 
     // Stopping the sender should have completed the second message's
-    // in-progess send, so queue size should be 1.
+    // in-progress send, so queue size should be 1.
     ASSERT_EQ(1, getQueueSize());
 }
 

--- a/src/lib/dhcpsrv/tests/daemon_unittest.cc
+++ b/src/lib/dhcpsrv/tests/daemon_unittest.cc
@@ -262,7 +262,7 @@ TEST_F(DaemonTest, PIDFileCleanup) {
 }
 
 // Checks that configureLogger method is behaving properly.
-// More dedicated tests are availablef for LogConfigParser class.
+// More dedicated tests are available for LogConfigParser class.
 // See logger_unittest.cc
 TEST_F(DaemonTest, parsingConsoleOutput) {
     CfgMgr::instance().setVerbose(false);

--- a/src/lib/dhcpsrv/tests/dhcp4o6_ipc_unittest.cc
+++ b/src/lib/dhcpsrv/tests/dhcp4o6_ipc_unittest.cc
@@ -64,7 +64,7 @@ protected:
     /// @param msg_type Message type.
     /// @param postfix Postfix to be appended to the remote address. For example,
     /// for postfix = 5 the resulting remote address will be 2001:db8:1::5.
-    /// The postifx value is also used to generate the postfix for the interface.
+    /// The postfix value is also used to generate the postfix for the interface.
     /// The possible interface names are "eth0" and "eth1". For even postfix values
     /// the "eth0" will be used, for odd postfix values "eth1" will be used.
     ///
@@ -164,7 +164,7 @@ Dhcp4o6IpcBaseTest::createDHCPv4o6Message(uint16_t msg_type,
     // the servers. The receiving server will check that such interface
     // is present in the system. The fake configuration we're using for
     // this test includes two interfaces: "eth0" and "eth1". Therefore,
-    // we pick one or another, depending on the index of the interation.
+    // we pick one or another, depending on the index of the iteration.
     pkt->setIface(concatenate("eth", postfix % 2));
 
     // The remote address of the sender of the DHCPv6 packet is carried
@@ -260,7 +260,7 @@ Dhcp4o6IpcBaseTest::testSendReceive(uint16_t iterations_num,
         // in the source packet.
         has_vendor_option.push_back(static_cast<bool>(pkt->getOption(D6O_VENDOR_OPTS)));
 
-        // Actaully send the message through the IPC.
+        // Actually send the message through the IPC.
         ASSERT_NO_THROW(ipc_src.send(pkt))
             << "Failed to send the message over the IPC for iteration " << i;
     }
@@ -449,7 +449,7 @@ TEST_F(Dhcp4o6IpcBaseTest, receiveWithoutVendorOption) {
     testReceiveError(pkt);
 }
 
-// This test verifies that receving packet over the IPC fails when the
+// This test verifies that receiving packet over the IPC fails when the
 // enterprise ID carried in the vendor option is invalid.
 TEST_F(Dhcp4o6IpcBaseTest, receiveInvalidEnterpriseId) {
     Pkt6Ptr pkt(new Pkt6(DHCPV6_DHCPV4_QUERY, 0));
@@ -501,7 +501,7 @@ TEST_F(Dhcp4o6IpcBaseTest, receiveWithInvalidInterface) {
 }
 
 
-// This test verifies that receving packet over the IPC fails when the
+// This test verifies that receiving packet over the IPC fails when the
 // source address option is not present.
 TEST_F(Dhcp4o6IpcBaseTest, receiveWithoutSourceAddressOption) {
     Pkt6Ptr pkt(new Pkt6(DHCPV6_DHCPV4_QUERY, 0));

--- a/src/lib/dhcpsrv/tests/dhcp_parsers_unittest.cc
+++ b/src/lib/dhcpsrv/tests/dhcp_parsers_unittest.cc
@@ -187,7 +187,7 @@ TEST_F(DhcpParserTest, uint32ParserTest) {
     Uint32StoragePtr storage(new Uint32Storage());
     Uint32Parser parser(name, storage);
 
-    // Verify that parser with rejects a non-interger element.
+    // Verify that parser with rejects a non-integer element.
     ElementPtr wrong_element = Element::create("I am a string");
     EXPECT_THROW(parser.build(wrong_element), isc::BadValue);
 
@@ -390,7 +390,7 @@ public:
     /// and parse them.
     /// @param config is the configuration string to parse
     ///
-    /// @return retuns 0 if the configuration parsed successfully,
+    /// @return 0 if the configuration parsed successfully,
     /// non-zero otherwise failure.
     int parseConfiguration(const std::string& config) {
         int rcode_ = 1;
@@ -1213,7 +1213,7 @@ TEST_F(ParseConfigTest, reconfigureSameHooksLibraries) {
     ASSERT_TRUE(rcode == 0) << error_text_;
 
     // The list has not changed between the two parse operations. However,
-    // the paramters (or the files they could point to) could have
+    // the parameters (or the files they could point to) could have
     // changed, so the libraries are reloaded anyway.
     HookLibsCollection libraries;
     bool changed;
@@ -2364,7 +2364,7 @@ TEST_F(ParseConfigTest, validRelayInfo6) {
     // Let's check negative scenario (wrong family type)
     EXPECT_THROW(parser->build(json_bogus1), DhcpConfigError);
 
-    // Unparseable text that looks like IPv6 address, but has too many colons
+    // Unparsable text that looks like IPv6 address, but has too many colons
     EXPECT_THROW(parser->build(json_bogus2), DhcpConfigError);
 }
 

--- a/src/lib/dhcpsrv/tests/generic_host_data_source_unittest.cc
+++ b/src/lib/dhcpsrv/tests/generic_host_data_source_unittest.cc
@@ -382,7 +382,7 @@ GenericHostDataSourceTest::compareOptions(const ConstCfgOptionPtr& cfg1,
             // Options must be represented by the same C++ class derived from
             // the Option class.
             EXPECT_TRUE(typeid(*option1) == typeid(*option2))
-                << "Comapared DHCP options, having option code "
+                << "Compared DHCP options, having option code "
                 << desc1.option_->getType() << " and belonging to the "
                 << space << " option space, are represented "
                 "by different C++ classes: "
@@ -823,7 +823,7 @@ GenericHostDataSourceTest::testMultipleSubnets(int subnets,
         EXPECT_EQ(1000 + i++, (*it)->getIPv4SubnetID());
     }
 
-    // Finally, check that the hosts can be retrived by HW address or DUID
+    // Finally, check that the hosts can be retrieved by HW address or DUID
     ConstHostCollection all_by_id =
         hdsptr_->getAll(id, &host->getIdentifier()[0],
                         host->getIdentifier().size());
@@ -945,7 +945,7 @@ GenericHostDataSourceTest::testSubnetId6(int subnets, Host::IdentifierType id) {
         EXPECT_EQ(i + 1000, from_hds->getIPv6SubnetID());
     }
 
-    // Check that the hosts can all be retrived by HW address or DUID
+    // Check that the hosts can all be retrieved by HW address or DUID
     ConstHostCollection all_by_id = hdsptr_->getAll(id, &host->getIdentifier()[0],
                                                     host->getIdentifier().size());
     ASSERT_EQ(subnets, all_by_id.size());

--- a/src/lib/dhcpsrv/tests/generic_host_data_source_unittest.h
+++ b/src/lib/dhcpsrv/tests/generic_host_data_source_unittest.h
@@ -88,7 +88,7 @@ public:
 
     /// @brief Compares hardware addresses of the two hosts.
     ///
-    /// This method compares two hwardware address and uses gtest
+    /// This method compares two hardware address and uses gtest
     /// macros to signal unexpected (mismatch if expect_match is true;
     /// match if expect_match is false) values.
     ///
@@ -393,7 +393,7 @@ public:
     void testClientIdNotHWAddr();
 
     /// @brief Test adds specified number of hosts with unique hostnames, then
-    /// retrives them and checks that the hostnames are set properly.
+    /// retrieves them and checks that the hostnames are set properly.
     ///
     /// Uses gtest macros to report failures.
     ///

--- a/src/lib/dhcpsrv/tests/generic_lease_mgr_unittest.cc
+++ b/src/lib/dhcpsrv/tests/generic_lease_mgr_unittest.cc
@@ -1566,7 +1566,7 @@ GenericLeaseMgrTest::testRecreateLease4() {
     EXPECT_TRUE(lmptr_->addLease(lease));
     lmptr_->commit();
 
-    // Check that the lease has been successfuly added.
+    // Check that the lease has been successfully added.
     Lease4Ptr l_returned = lmptr_->getLease4(ioaddress4_[0]);
     ASSERT_TRUE(l_returned);
     detailCompareLease(lease, l_returned);
@@ -1606,7 +1606,7 @@ GenericLeaseMgrTest::testRecreateLease6() {
     EXPECT_TRUE(lmptr_->addLease(lease));
     lmptr_->commit();
 
-    // Check that the lease has been successfuly added.
+    // Check that the lease has been successfully added.
     Lease6Ptr l_returned = lmptr_->getLease6(Lease::TYPE_NA, ioaddress6_[0]);
     ASSERT_TRUE(l_returned);
     detailCompareLease(lease, l_returned);
@@ -2535,7 +2535,7 @@ GenericLeaseMgrTest::testRecountLeaseStats4() {
     // Now let's add leases to subnet 2.
     subnet_id = 2;
 
-    // Insert one delined lease.
+    // Insert one declined lease.
     makeLease4("192.0.2.2", subnet_id, Lease::STATE_DECLINED);
 
     // Update the expected stats.

--- a/src/lib/dhcpsrv/tests/generic_lease_mgr_unittest.h
+++ b/src/lib/dhcpsrv/tests/generic_lease_mgr_unittest.h
@@ -307,7 +307,7 @@ public:
     /// @brief Checks that the expired DHCPv4 leases can be retrieved.
     ///
     /// This test checks the following:
-    /// - all expired and not reclaimed leases are retured
+    /// - all expired and not reclaimed leases are returned
     /// - number of leases returned can be limited
     /// - leases are returned in the order from the most expired to the
     ///   least expired
@@ -317,7 +317,7 @@ public:
     /// @brief Checks that the expired IPv6 leases can be retrieved.
     ///
     /// This test checks the following:
-    /// - all expired and not reclaimed leases are retured
+    /// - all expired and not reclaimed leases are returned
     /// - number of leases returned can be limited
     /// - leases are returned in the order from the most expired to the
     ///   least expired

--- a/src/lib/dhcpsrv/tests/host_mgr_unittest.cc
+++ b/src/lib/dhcpsrv/tests/host_mgr_unittest.cc
@@ -438,7 +438,7 @@ TEST_F(MySQLHostMgrTest, getAll) {
 }
 
 // This test verifies that IPv4 reservations for a particular client can
-// be retrieved from the configuration file and a database simulatneously.
+// be retrieved from the configuration file and a database simultaneously.
 TEST_F(MySQLHostMgrTest, getAll4) {
     testGetAll4(*getCfgHosts(), HostMgr::instance());
 }
@@ -515,7 +515,7 @@ TEST_F(PostgreSQLHostMgrTest, getAll) {
 }
 
 // This test verifies that IPv4 reservations for a particular client can
-// be retrieved from the configuration file and a database simulatneously.
+// be retrieved from the configuration file and a database simultaneously.
 TEST_F(PostgreSQLHostMgrTest, getAll4) {
     testGetAll4(*getCfgHosts(), HostMgr::instance());
 }

--- a/src/lib/dhcpsrv/tests/host_reservation_parser_unittest.cc
+++ b/src/lib/dhcpsrv/tests/host_reservation_parser_unittest.cc
@@ -129,7 +129,7 @@ protected:
         EXPECT_TRUE(hosts[0]->getCfgOption6()->empty());
     }
 
-    /// @brief This test verfies that the parser can parse a DHCPv4
+    /// @brief This test verifies that the parser can parse a DHCPv4
     /// reservation configuration including a specific identifier.
     ///
     /// @param identifier_name Identifier name.
@@ -163,7 +163,7 @@ protected:
         EXPECT_TRUE(hosts[0]->getHostname().empty());
     }
 
-    /// @brief This test verfies that the parser returns an error when
+    /// @brief This test verifies that the parser returns an error when
     /// configuration is invalid.
     ///
     /// @param config JSON configuration to be tested.
@@ -215,7 +215,7 @@ HostReservationParserTest::TearDown() {
     CfgMgr::instance().clear();
 }
 
-// This test verfies that the parser can parse the reservation entry for
+// This test verifies that the parser can parse the reservation entry for
 // which hw-address is a host identifier.
 TEST_F(HostReservationParserTest, dhcp4HWaddr) {
     testIdentifier4("hw-address", "1:2:3:4:5:6", Host::IDENT_HWADDR,
@@ -505,7 +505,7 @@ TEST_F(HostReservationParserTest, invalidParameterName) {
     testInvalidConfig<HostReservationParser4>(config);
 }
 
-// This test verfies that the parser can parse the IPv6 reservation entry for
+// This test verifies that the parser can parse the IPv6 reservation entry for
 // which hw-address is a host identifier.
 TEST_F(HostReservationParserTest, dhcp6HWaddr) {
     std::string config = "{ \"hw-address\": \"01:02:03:04:05:06\","
@@ -553,7 +553,7 @@ TEST_F(HostReservationParserTest, dhcp6HWaddr) {
 
 }
 
-// This test verfies that the parser can parse the IPv6 reservation entry for
+// This test verifies that the parser can parse the IPv6 reservation entry for
 // which DUID is a host identifier.
 TEST_F(HostReservationParserTest, dhcp6DUID) {
     std::string config = "{ \"duid\": \"01:02:03:04:05:06:07:08:09:0A\","
@@ -613,7 +613,7 @@ TEST_F(HostReservationParserTest, dhcp6ClientId) {
     testInvalidConfig<HostReservationParser6>(config);
 }
 
-// This test verfies that the parser can parse the IPv6 reservation entry
+// This test verifies that the parser can parse the IPv6 reservation entry
 // which lacks hostname parameter.
 TEST_F(HostReservationParserTest, dhcp6NoHostname) {
     std::string config = "{ \"duid\": \"01:02:03:04:05:06:07:08:09:0A\","

--- a/src/lib/dhcpsrv/tests/host_unittest.cc
+++ b/src/lib/dhcpsrv/tests/host_unittest.cc
@@ -186,7 +186,7 @@ TEST_F(HostTest, getIdentifier) {
     EXPECT_THROW(Host::getIdentifierType("unuspported"), isc::BadValue);
 }
 
-// This test verfies that it is possible to create a Host object
+// This test verifies that it is possible to create a Host object
 // using hardware address in the textual format.
 TEST_F(HostTest, createFromHWAddrString) {
     boost::scoped_ptr<Host> host;
@@ -680,7 +680,7 @@ TEST_F(HostTest, setValues) {
     EXPECT_THROW(host->setIPv4Reservation(IOAddress("2001:db8:1::1")),
                  isc::BadValue);
     // Zero address can't be set, the removeIPv4Reservation should be
-    // used intead.
+    // used instead.
     EXPECT_THROW(host->setIPv4Reservation(IOAddress::IPV4_ZERO_ADDRESS()),
                  isc::BadValue);
     // Broadcast address can't be set.

--- a/src/lib/dhcpsrv/tests/lease_file_loader_unittest.cc
+++ b/src/lib/dhcpsrv/tests/lease_file_loader_unittest.cc
@@ -99,7 +99,7 @@ public:
         LeaseFileLoader::write<LeaseObjectType, LeaseFileType, StorageType>
             (lease_file, storage);
 
-        // Compare to see if we got what we exepcted.
+        // Compare to see if we got what we expected.
         EXPECT_EQ(compare, io_.readFile());
     }
 

--- a/src/lib/dhcpsrv/tests/lease_unittest.cc
+++ b/src/lib/dhcpsrv/tests/lease_unittest.cc
@@ -98,7 +98,7 @@ TEST_F(Lease4Test, constructor) {
     }
 }
 
-// This test verfies that copy constructor copies Lease4 fields correctly.
+// This test verifies that copy constructor copies Lease4 fields correctly.
 TEST_F(Lease4Test, copyConstructor) {
 
     // Get current time for the use in Lease4.
@@ -134,7 +134,7 @@ TEST_F(Lease4Test, copyConstructor) {
     EXPECT_TRUE(lease == copied_lease2);
 }
 
-// This test verfies that the assignment operator copies all Lease4 fields
+// This test verifies that the assignment operator copies all Lease4 fields
 // correctly.
 TEST_F(Lease4Test, operatorAssign) {
 

--- a/src/lib/dhcpsrv/tests/logging_info_unittest.cc
+++ b/src/lib/dhcpsrv/tests/logging_info_unittest.cc
@@ -120,7 +120,7 @@ TEST_F(LoggingInfoTest, equalityOperators) {
     EXPECT_TRUE(info1 == info2);
     EXPECT_FALSE(info1 != info2);
 
-    // Create two different desinations.
+    // Create two different destinations.
     LoggingDestination dest1;
     LoggingDestination dest2;
     dest1.output_ = "foo";

--- a/src/lib/dhcpsrv/tests/logging_unittest.cc
+++ b/src/lib/dhcpsrv/tests/logging_unittest.cc
@@ -44,7 +44,7 @@ TEST_F(LoggingTest, basicSpec) {
     ASSERT_NO_THROW(isc::config::moduleSpecFromFile(specfile));
 }
 
-// Checks that contructor is able to process specified storage properly
+// Checks that the constructor is able to process specified storage properly.
 TEST_F(LoggingTest, constructor) {
 
     SrvConfigPtr null_ptr;
@@ -249,7 +249,7 @@ TEST_F(LoggingTest, multipleLoggingDestinations) {
 /// @todo There is no easy way to test applyConfiguration() and defaultLogging().
 /// To test them, it would require instrumenting log4cplus to actually fake
 /// the logging set up. Alternatively, we could develop set of test suites
-/// that check each logging destination spearately (e.g. configure log file, then
+/// that check each logging destination separately (e.g. configure log file, then
 /// check if the file is indeed created or configure stdout destination, then
 /// swap console file descriptors and check that messages are really logged.
 

--- a/src/lib/dhcpsrv/tests/memfile_lease_mgr_unittest.cc
+++ b/src/lib/dhcpsrv/tests/memfile_lease_mgr_unittest.cc
@@ -1647,7 +1647,7 @@ TEST_F(MemfileLeaseMgrTest, lease4ContainerIndexUpdate) {
     // pick a lease.
     std::vector<IOAddress> lease_addresses;
 
-    // Generarate random leases. We remember their addresses in
+    // Generate random leases. We remember their addresses in
     // lease_addresses.
     for (uint32_t i = 0; i < leases_cnt; ++i) {
         Lease4Ptr lease = initiateRandomLease4(addr);
@@ -1786,7 +1786,7 @@ TEST_F(MemfileLeaseMgrTest, lease6ContainerIndexUpdate) {
     // pick a lease.
     std::vector<IOAddress> lease_addresses;
 
-    // Generarate random leases. We remember their addresses in
+    // Generate random leases. We remember their addresses in
     // lease_addresses.
     for (uint32_t i = 0; i < leases_cnt; ++i) {
         Lease6Ptr lease = initiateRandomLease6(addr);

--- a/src/lib/dhcpsrv/tests/ncr_generator_unittest.cc
+++ b/src/lib/dhcpsrv/tests/ncr_generator_unittest.cc
@@ -110,7 +110,7 @@ public:
     ///
     /// @param type An expected type of the NameChangeRequest (Add or Remove).
     /// @param reverse An expected setting of the reverse update flag.
-    /// @param forward An expected setting of the forward udpate flag.
+    /// @param forward An expected setting of the forward update flag.
     /// @param addr A string representation of the IPv6 address held in the
     /// NameChangeRequest.
     /// @param dhcid An expected DHCID value.
@@ -118,7 +118,7 @@ public:
     /// dhcp_ddns::D2Dhcid::createDigest() with the appropriate arguments. This
     /// method uses encryption tools to produce the value which cannot be
     /// easily duplicated by hand.  It is more or less necessary to generate
-    /// these values programmatically and place them here. Should the
+    /// these values programatically and place them here. Should the
     /// underlying implementation of createDigest() change these test values
     /// will likely need to be updated as well.
     /// @param expires A timestamp when the lease associated with the

--- a/src/lib/dhcpsrv/tests/pgsql_exchange_unittest.cc
+++ b/src/lib/dhcpsrv/tests/pgsql_exchange_unittest.cc
@@ -216,7 +216,7 @@ public:
     /// @brief Executes a SQL statement and tests for an expected outcome
     ///
     /// @param r pointer which will contain the result set returned by the
-    /// statment's execution.
+    /// statement's execution.
     /// @param sql string containing the SQL statement text.  Note that
     /// PostgreSQL supports executing text which contains more than one SQL
     /// statement separated by semicolons.
@@ -236,7 +236,7 @@ public:
     /// @brief Executes a SQL statement and tests for an expected outcome
     ///
     /// @param r pointer which will contain the result set returned by the
-    /// statment's execution.
+    /// statement's execution.
     /// @param statement statement descriptor of the prepared statement
     /// to execute.
     /// @param bind_array bind array containing the input values to submit
@@ -268,7 +268,7 @@ public:
     /// of the defined columns, in the order they are defined.
     ///
     /// @param r pointer which will contain the result set returned by the
-    /// statment's execution.
+    /// statement's execution.
     /// @param exp_rows expected number of rows fetched. (This can be 0).
     /// @lineno line number from where the call was invoked
     ///
@@ -308,7 +308,7 @@ TEST_F(PgSqlBasicsTest, rowColumnBasics) {
     PgSqlResultPtr r;
     FETCH_ROWS(r, 0);
 
-    // Column meta-data is deteremined by the select statement and is
+    // Column meta-data is determined by the select statement and is
     // present whether or not any rows were returned.
     EXPECT_EQ(r->getCols(), NUM_BASIC_COLS);
 

--- a/src/lib/dhcpsrv/tests/subnet_unittest.cc
+++ b/src/lib/dhcpsrv/tests/subnet_unittest.cc
@@ -298,7 +298,7 @@ TEST(Subnet4Test, clientClasses) {
     EXPECT_TRUE(subnet->clientSupported(bar_class));
     EXPECT_TRUE(subnet->clientSupported(three_classes));
 
-    // Let's allow only clients belongning to "bar" class.
+    // Let's allow only clients belonging to "bar" class.
     subnet->allowClientClass("bar");
 
     EXPECT_FALSE(subnet->clientSupported(no_class));
@@ -329,7 +329,7 @@ TEST(Subnet4Test, clientClassesMultiple) {
     EXPECT_TRUE(subnet->clientSupported(foo_class));
     EXPECT_TRUE(subnet->clientSupported(bar_class));
 
-    // Let's allow clients belongning to "bar" or "foo" class.
+    // Let's allow clients belonging to "bar" or "foo" class.
     subnet->allowClientClass("bar");
     subnet->allowClientClass("foo");
 
@@ -462,7 +462,7 @@ TEST(Subnet4Test, PoolType) {
     EXPECT_EQ(pool1, subnet->getPool(Lease::TYPE_V4, IOAddress("192.2.1.5")));
     EXPECT_EQ(pool2, subnet->getPool(Lease::TYPE_V4, IOAddress("192.2.2.254")));
 
-    // Try with bogus hints (hints should be ingored)
+    // Try with bogus hints (hints should be ignored)
     EXPECT_EQ(pool1, subnet->getPool(Lease::TYPE_V4, IOAddress("10.1.1.1")));
 
     // Trying to add Pool6 to Subnet4 is a big no,no!
@@ -694,7 +694,7 @@ TEST(Subnet6Test, poolTypes) {
     EXPECT_EQ(pool2, subnet->getPool(Lease::TYPE_TA, IOAddress("2001:db8:1:2::1")));
     EXPECT_EQ(pool3, subnet->getPool(Lease::TYPE_PD, IOAddress("2001:db8:1:3::1")));
 
-    // Try with bogus hints (hints should be ingored)
+    // Try with bogus hints (hints should be ignored)
     EXPECT_EQ(pool1, subnet->getPool(Lease::TYPE_NA, IOAddress("2001:db8:1:7::1")));
     EXPECT_EQ(pool2, subnet->getPool(Lease::TYPE_TA, IOAddress("2001:db8:1:7::1")));
     EXPECT_EQ(pool3, subnet->getPool(Lease::TYPE_PD, IOAddress("2001:db8:1:7::1")));
@@ -745,7 +745,7 @@ TEST(Subnet6Test, clientClasses) {
     EXPECT_TRUE(subnet->clientSupported(bar_class));
     EXPECT_TRUE(subnet->clientSupported(three_classes));
 
-    // Let's allow only clients belongning to "bar" class.
+    // Let's allow only clients belonging to "bar" class.
     subnet->allowClientClass("bar");
 
     EXPECT_FALSE(subnet->clientSupported(no_class));
@@ -776,7 +776,7 @@ TEST(Subnet6Test, clientClassesMultiple) {
     EXPECT_TRUE(subnet->clientSupported(foo_class));
     EXPECT_TRUE(subnet->clientSupported(bar_class));
 
-    // Let's allow only clients belongning to "foo" or "bar" class.
+    // Let's allow only clients belonging to "foo" or "bar" class.
     subnet->allowClientClass("foo");
     subnet->allowClientClass("bar");
 
@@ -940,7 +940,7 @@ TEST(Subnet6Test, addNonUniqueOptions) {
                   OptionContainerTypeIndex::const_iterator> range =
             idx.equal_range(code);
         // Distance between iterators indicates how many options
-        // have been retured for the particular code.
+        // have been returned for the particular code.
         ASSERT_EQ(2, distance(range.first, range.second));
         // Check that returned options actually have the expected option code.
         for (OptionContainerTypeIndex::const_iterator option_desc = range.first;

--- a/src/lib/dhcpsrv/tests/timer_mgr_unittest.cc
+++ b/src/lib/dhcpsrv/tests/timer_mgr_unittest.cc
@@ -217,7 +217,7 @@ TEST_F(TimerMgrTest, unregisterTimer) {
     ASSERT_GT(calls_count, 0);
 
     // Check that an attempt to unregister a non-existing timer would
-    // result in exeception.
+    // result in exception.
     ASSERT_THROW(timer_mgr_->unregisterTimer("timer2"), BadValue);
     // Number of timers shouldn't have changed.
     ASSERT_EQ(1, timer_mgr_->timersCount());
@@ -374,7 +374,7 @@ TEST_F(TimerMgrTest, scheduleTimers) {
 
     // We have been running the timer for 1000ms at the interval of
     // 50ms. The maximum number of callbacks is 20. However, the
-    // callback itself takes time. Stoping the thread takes time.
+    // callback itself takes time. Stopping the thread takes time.
     // So, the real number differs significantly. We don't know
     // exactly how many have been executed. It should be more
     // than 10 for sure. But we really made up the numbers here.

--- a/src/lib/dhcpsrv/testutils/config_result_check.cc
+++ b/src/lib/dhcpsrv/testutils/config_result_check.cc
@@ -40,7 +40,7 @@ bool errorContainsPosition(ConstElementPtr error_element,
         // If the file name is present, check that it is followed by the line
         // number and position within the line.
         if (pos != std::string::npos) {
-            // Split the string starting at the begining of the <filename>. It
+            // Split the string starting at the beginning of the <filename>. It
             // should return a vector of strings.
             std::string sub = error_string.substr(pos);
             std::vector<std::string> split_pos;

--- a/src/lib/dhcpsrv/testutils/config_result_check.h
+++ b/src/lib/dhcpsrv/testutils/config_result_check.h
@@ -18,7 +18,7 @@ namespace test {
 ///
 /// This function checks that the error string returned by the configuration
 /// parsers contains the position of the element which caused an error. The
-/// error string is expected to contain at least one occurence of the following:
+/// error string is expected to contain at least one occurrence of the following:
 ///
 /// @code
 ///     [filename]:[linenum]:[pos]

--- a/src/lib/dhcpsrv/timer_mgr.cc
+++ b/src/lib/dhcpsrv/timer_mgr.cc
@@ -28,7 +28,7 @@ namespace {
 
 /// @brief Simple RAII object setting value to true while in scope.
 ///
-/// This class is useful to temporarly set the value to true and
+/// This class is useful to temporarily set the value to true and
 /// automatically reset it to false when the object is destroyed
 /// as a result of return or exception.
 class ScopedTrue {

--- a/src/lib/dhcpsrv/writable_host_data_source.h
+++ b/src/lib/dhcpsrv/writable_host_data_source.h
@@ -47,7 +47,7 @@ public:
     /// because a particular client may have reservations in multiple subnets.
     ///
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -71,7 +71,7 @@ public:
     /// @brief Returns a host connected to the IPv4 subnet.
     ///
     /// Implementations of this method should guard against the case when
-    /// mutliple instances of the @c Host are present, e.g. when two
+    /// multiple instances of the @c Host are present, e.g. when two
     /// @c Host objects are found, one for the DUID, another one for the
     /// HW address. In such case, an implementation of this method
     /// should throw an exception.
@@ -90,7 +90,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///
@@ -103,7 +103,7 @@ public:
     /// @brief Returns a host connected to the IPv6 subnet.
     ///
     /// Implementations of this method should guard against the case when
-    /// mutliple instances of the @c Host are present, e.g. when two
+    /// multiple instances of the @c Host are present, e.g. when two
     /// @c Host objects are found, one for the DUID, another one for the
     /// HW address. In such case, an implementation of this method
     /// should throw an exception.
@@ -122,7 +122,7 @@ public:
     ///
     /// @param subnet_id Subnet identifier.
     /// @param identifier_type Identifier type.
-    /// @param identifier_begin Pointer to a begining of a buffer containing
+    /// @param identifier_begin Pointer to a beginning of a buffer containing
     /// an identifier.
     /// @param identifier_len Identifier length.
     ///

--- a/src/lib/dns/labelsequence.cc
+++ b/src/lib/dns/labelsequence.cc
@@ -19,7 +19,7 @@ namespace dns {
 
 LabelSequence::LabelSequence(const void* buf) {
 #ifdef ENABLE_DEBUG
-    // In non-debug mode, derefencing the NULL pointer further below
+    // In non-debug mode, dereferencing the NULL pointer further below
     // will lead to a crash, so disabling this check is not
     // unsafe. Except for a programming mistake, this case should not
     // happen.

--- a/src/lib/dns/messagerenderer.h
+++ b/src/lib/dns/messagerenderer.h
@@ -64,7 +64,7 @@ class LabelSequence;
 ///     implementation is really needed, we can make them virtual in future.
 ///     The only one that is virtual is writeName and it's because this
 ///     function is much more complicated, therefore there's a lot of space
-///     for different implementations or behaviours.
+///     for different implementations or different behavior.
 class AbstractMessageRenderer {
 public:
     /// \brief Compression mode constants.
@@ -390,6 +390,6 @@ private:
 }
 #endif // MESSAGERENDERER_H
 
-// Local Variables: 
+// Local Variables:
 // mode: c++
-// End: 
+// End:

--- a/src/lib/dns/rdatafields.cc
+++ b/src/lib/dns/rdatafields.cc
@@ -98,7 +98,7 @@ public:
         extendData();
         return (fields_);
     }
-    // We use generict write* methods, with the exception of writeName.
+    // We use generic write* methods, with the exception of writeName.
     // So new data can arrive without us knowing it, this considers all new
     // data to be just data and extends the fields to take it into account.
     size_t last_data_pos_;

--- a/src/lib/dns/rrcollator.h
+++ b/src/lib/dns/rrcollator.h
@@ -18,7 +18,7 @@ namespace dns {
 
 /// \brief A converter from a stream of RRs to a stream of collated RRsets
 ///
-/// This class is mainly intended to be a helper used as an adaptor for
+/// This class is mainly intended to be a helper used as an adapter for
 /// user applications of the \c MasterLoader class; it works as a callback
 /// for \c MasterLoader, buffers given RRs from the loader, collating
 /// consecutive RRs that belong to the same RRset (ones having the same
@@ -93,7 +93,7 @@ public:
     /// \brief Return \c MasterLoader compatible callback.
     ///
     /// This method returns a functor in the form of \c AddRRCallback
-    /// that works as an adaptor between \c MasterLoader and an application
+    /// that works as an adapter between \c MasterLoader and an application
     /// that needs to get a stream of RRsets.  When the returned callback
     /// is called, this \c RRCollator object accepts the corresponding RR,
     /// and collates it with other RRs of the same RRset if necessary.

--- a/src/lib/dns/rrset_collection_base.h
+++ b/src/lib/dns/rrset_collection_base.h
@@ -108,7 +108,7 @@ protected:
     /// used by the public iterator.  Derived classes of
     /// \c RRsetCollectionBase are supposed to implement this class and
     /// the \c getBeginning() and \c getEnd() methods, so that the
-    /// public interator interface can be provided. This is a forward
+    /// public iterator interface can be provided. This is a forward
     /// iterator only.
     class Iter {
     public:

--- a/src/lib/dns/serial.h
+++ b/src/lib/dns/serial.h
@@ -58,7 +58,7 @@ public:
 
     /// \brief Direct assignment from value
     ///
-    /// \param value the uint32_t value to assing
+    /// \param value the uint32_t value to assign
     void operator=(uint32_t value) { value_ = value; }
 
     /// \brief Returns the uint32_t representation of this serial value

--- a/src/lib/dns/tests/master_loader_unittest.cc
+++ b/src/lib/dns/tests/master_loader_unittest.cc
@@ -861,7 +861,7 @@ TEST_F(MasterLoaderTest, incrementalLoad) {
 // saying so.
 TEST_F(MasterLoaderTest, invalidFile) {
     setLoader("This file doesn't exist at all",
-              Name("exmaple.org."), RRClass::IN(), MasterLoader::MANY_ERRORS);
+              Name("example.org."), RRClass::IN(), MasterLoader::MANY_ERRORS);
 
     // Nothing yet. The loader is dormant until invoked.
     // Is it really what we want?
@@ -941,7 +941,7 @@ struct ErrorCase {
     { "$INCLUDES " TEST_DATA_SRCDIR "/example.org",
         "Unknown directive 'INCLUDES'", "Include too long" },
     { "$INCLUDE", "unexpected end of input", "Missing include path" },
-    // The following two error messages are system dependant, omitting
+    // The following two error messages are system dependent, omitting
     { "$INCLUDE /file/not/found", NULL, "Include file not found" },
     { "$INCLUDE /file/not/found example.org. and here goes bunch of garbage",
         NULL, "Include file not found and garbage at the end of line" },

--- a/src/lib/dns/tests/name_unittest.cc
+++ b/src/lib/dns/tests/name_unittest.cc
@@ -355,7 +355,7 @@ TEST_F(NameTest, atSign) {
     EXPECT_EQ(Name::ROOT_NAME(), Name("@"));
 
     // It is not alone. It is taken verbatim. We check the name converted
-    // back to the textual form, since checking it agains other name object
+    // back to the textual form, since checking it against other name object
     // may be wrong -- if we create it wrong the same way as the tested
     // object.
     EXPECT_EQ("\\@.", Name("@.").toText());

--- a/src/lib/dns/tests/rdata_nsec3_unittest.cc
+++ b/src/lib/dns/tests/rdata_nsec3_unittest.cc
@@ -204,7 +204,7 @@ TEST_F(Rdata_NSEC3_Test, compare) {
     EXPECT_THROW(generic::NSEC3(nsec3_txt).compare(*rdata_nomatch),
                  bad_cast);
 
-    // test RDATAs, sorted in the ascendent order.  We only check comparison
+    // test RDATAs, sorted in the ascending order.  We only check comparison
     // on NSEC3-specific fields.  Bitmap comparison is tested in the bitmap
     // tests.  Common cases for NSEC3 and NSECPARAM3 are in their shared tests.
     vector<generic::NSEC3> compare_set;

--- a/src/lib/dns/tests/rdata_nsec3param_like_unittest.cc
+++ b/src/lib/dns/tests/rdata_nsec3param_like_unittest.cc
@@ -244,7 +244,7 @@ TYPED_TEST(NSEC3PARAMLikeTest, toWire) {
 }
 
 TYPED_TEST(NSEC3PARAMLikeTest, compare) {
-    // test RDATAs, sorted in the ascendent order.
+    // test RDATAs, sorted in the ascending order.
     this->compare_set.push_back(this->fromText("0 0 0 D399EAAB" +
                                                this->getCommonText()));
     this->compare_set.push_back(this->fromText("1 0 0 D399EAAB" +

--- a/src/lib/dns/tests/rdata_nsec_unittest.cc
+++ b/src/lib/dns/tests/rdata_nsec_unittest.cc
@@ -117,7 +117,7 @@ TEST_F(Rdata_NSEC_Test, compare) {
     EXPECT_THROW(generic::NSEC(nsec_txt).compare(*rdata_nomatch),
                  bad_cast);
 
-    // test RDATAs, sorted in the ascendent order.  We only compare the
+    // test RDATAs, sorted in the ascending order.  We only compare the
     // next name here.  Bitmap comparison is tested in the bitmap tests.
     // Note that names are compared as wire-format data, not based on the
     // domain name comparison.

--- a/src/lib/dns/tests/rdata_pimpl_holder_unittest.cc
+++ b/src/lib/dns/tests/rdata_pimpl_holder_unittest.cc
@@ -20,7 +20,7 @@ TEST(RdataPimplHolderTest, all) {
     EXPECT_EQ(i1, holder1.get());
     // Obviously the value should match too.
     EXPECT_EQ(42, *holder1.get());
-    // We don't explictly delete i or holder1, so it should not leak
+    // We don't explicitly delete i or holder1, so it should not leak
     // anything when the test is done (checked by Valgrind).
 
     // The following cases are similar:

--- a/src/lib/dns/tests/rdata_soa_unittest.cc
+++ b/src/lib/dns/tests/rdata_soa_unittest.cc
@@ -231,7 +231,7 @@ TEST_F(Rdata_SOA_Test, compare) {
 
     // Compare other numeric fields: 1076895760 = 0x40302010,
     // 270544960 = 0x10203040.  These are chosen to make sure that machine
-    // endian doesn't confuse the comparison results.
+    // endianness doesn't confuse the comparison results.
     compareCheck(generic::SOA(". . 270544960 0 0 0 0"),
                  generic::SOA(". . 1076895760 0 0 0 0"));
     compareCheck(generic::SOA(". . 0 270544960 0 0 0"),

--- a/src/lib/dns/tests/rdata_srv_unittest.cc
+++ b/src/lib/dns/tests/rdata_srv_unittest.cc
@@ -179,7 +179,7 @@ TEST_F(Rdata_SRV_Test, toText) {
 }
 
 TEST_F(Rdata_SRV_Test, compare) {
-    // test RDATAs, sorted in the ascendent order.
+    // test RDATAs, sorted in the ascending order.
     vector<in::SRV> compare_set;
     compare_set.push_back(in::SRV("1 5 1500 a.example.com."));
     compare_set.push_back(in::SRV("2 5 1500 a.example.com."));

--- a/src/lib/dns/tests/rdata_tsig_unittest.cc
+++ b/src/lib/dns/tests/rdata_tsig_unittest.cc
@@ -167,7 +167,7 @@ TEST_F(Rdata_TSIG_Test, badText) {
     checkFromText_LexerError("foo 0 FUDGE 0 0 BADKEY 0");
     // MAC size is too large
     checkFromText_InvalidText("foo 0 0 65536 0 BADKEY 0");
-    // invalide MAC size (negative)
+    // invalid MAC size (negative)
     checkFromText_LexerError("foo 0 0 -1 0 BADKEY 0");
     // invalid MAC size (not a number)
     checkFromText_LexerError("foo 0 0 MACSIZE 0 BADKEY 0");
@@ -288,7 +288,7 @@ TEST_F(Rdata_TSIG_Test, createFromParams) {
                                               17, 0, NULL)));
 
     const uint8_t fake_data[] = { 0x14, 0x02, 0x84, 0x14, 0x02, 0x84,
-                                  0x14, 0x02, 0x84, 0x14, 0x02, 0x84 }; 
+                                  0x14, 0x02, 0x84, 0x14, 0x02, 0x84 };
     EXPECT_EQ(0, any::TSIG(valid_text2).compare(
                   any::TSIG(Name("hmac-sha256"), 1286779327, 300, 12,
                             fake_data, 16020, 16, 0, NULL)));
@@ -399,7 +399,7 @@ TEST_F(Rdata_TSIG_Test, toText) {
 }
 
 TEST_F(Rdata_TSIG_Test, compare) {
-    // test RDATAs, sorted in the ascendent order.
+    // test RDATAs, sorted in the ascending order.
     // "AAAA" encoded in BASE64 corresponds to 0x000000, so it should be the
     // smallest data of the same length.
     vector<any::TSIG> compare_set;

--- a/src/lib/dns/tests/testdata/rdata_nsec3_fromWire2.spec
+++ b/src/lib/dns/tests/testdata/rdata_nsec3_fromWire2.spec
@@ -1,6 +1,6 @@
 #
 # A malformed NSEC3 RDATA: RDLEN indicates it doesn't even contain the fixed
-# 5 octects
+# 5 octets
 #
 
 [custom]

--- a/src/lib/dns/tests/testdata/rdata_nsec3param_fromWire2.spec
+++ b/src/lib/dns/tests/testdata/rdata_nsec3param_fromWire2.spec
@@ -1,6 +1,6 @@
 #
 # A malformed NSEC3PARAM RDATA: RDLEN indicates it doesn't even contain the
-# fixed 5 octects
+# fixed 5 octets
 #
 
 [custom]

--- a/src/lib/dns/tsig.h
+++ b/src/lib/dns/tsig.h
@@ -414,7 +414,7 @@ public:
 protected:
     /// \brief Update internal HMAC state by more data.
     ///
-    /// This is used mostly internaly, when we need to verify a message without
+    /// This is used mostly internally, when we need to verify a message without
     /// TSIG signature in the middle of signed TCP stream. However, it is also
     /// used in tests, so it's protected instead of private, to allow tests
     /// in.

--- a/src/lib/eval/eval_context.h
+++ b/src/lib/eval/eval_context.h
@@ -22,7 +22,7 @@ YY_DECL;
 namespace isc {
 namespace eval {
 
-/// @brief Evaluation error exception raised when trying to parse an axceptions.
+/// @brief Evaluation error exception raised when trying to parse an exceptions.
 class EvalParseError : public isc::Exception {
 public:
     EvalParseError(const char* file, size_t line, const char* what) :
@@ -153,7 +153,7 @@ public:
     /// @brief Flag determining scanner debugging.
     bool trace_scanning_;
 
-    /// @brief Flag determing parser debugging.
+    /// @brief Flag determening parser debugging.
     bool trace_parsing_;
 
     /// @brief Option universe: DHCPv4 or DHCPv6.

--- a/src/lib/eval/parser.yy
+++ b/src/lib/eval/parser.yy
@@ -35,7 +35,7 @@ using namespace isc::eval;
 }
 
 %define api.token.prefix {TOKEN_}
-// Tokens in an order which makes sense and related to the intented use.
+// Tokens in an order which makes sense and related to the intended use.
 %token
   END  0  "end of file"
   LPAREN  "("

--- a/src/lib/eval/tests/context_unittest.cc
+++ b/src/lib/eval/tests/context_unittest.cc
@@ -189,13 +189,13 @@ public:
             return;
         }
 
-        // Parsing should succed and return a token.
+        // Parsing should succeed and return a token.
         EXPECT_TRUE(parsed_);
 
         // There should be the expected number of tokens.
         ASSERT_EQ(exp_tokens, eval.expression.size());
 
-        // checkt that the first token is TokenRelay6Option and that
+        // checked that the first token is TokenRelay6Option and that
         // is has the correct attributes
         checkTokenRelay6Option(eval.expression.at(0), exp_level, exp_code, exp_repr);
     }
@@ -212,7 +212,7 @@ public:
         EXPECT_EQ(type, pkt->getType());
     }
 
-    /// @brief Test that verifies access to the DHCP packet metadatas.
+    /// @brief Test that verifies access to the DHCP packet metadata.
     ///
     /// This test attempts to parse the expression, will check if the number
     /// of tokens is exactly as expected and then will try to verify if the
@@ -379,13 +379,13 @@ public:
             return;
         }
 
-        // Parsing should succed and return a token.
+        // Parsing should succeed and return a token.
         EXPECT_TRUE(parsed_);
 
         // There should be the expected number of tokens.
         ASSERT_EQ(exp_tokens, eval.expression.size());
 
-        // checkt that the first token is TokenRelay6Field and that
+        // checked that the first token is TokenRelay6Field and that
         // is has the correct attributes
         checkTokenRelay6Field(eval.expression.at(0), exp_level, exp_type);
     }
@@ -1359,7 +1359,7 @@ TEST_F(EvalContextTest, typeErrors) {
                "hexstring, expecting integer");
 
     // With the #4483 addition, all integers are treated as 4 byte strings,
-    // so those checks no longer makes sense. Commeting it out.
+    // so those checks no longer makes sense. Commenting it out.
     // checkError("concat('foo',3) == 'foo3'",
     //            "<string>:1.14: syntax error, unexpected integer");
     // checkError("concat(3,'foo') == '3foo'",

--- a/src/lib/eval/tests/token_unittest.cc
+++ b/src/lib/eval/tests/token_unittest.cc
@@ -301,7 +301,7 @@ public:
             OpaqueDataTuple tuple(len);
             tuple.assign(string(content[i]));
             if (u == Option::V4 && i == 0) {
-                // vendor-clas for v4 has a pecurilar quirk. The first tuple is being
+                // vendor-class for v4 has a peculiar quirk. The first tuple is being
                 // added, even if there's no data at all.
                 vendor_class_->setTuple(0, tuple);
             } else {
@@ -1546,7 +1546,7 @@ TEST_F(TokenTest, optionEqualFalse) {
     EXPECT_NO_THROW(t_->evaluate(*pkt4_, values_));
 
     // After evaluation there should be a single value that represents
-    // result of "foo" == "bar" comparision.
+    // result of "foo" == "bar" comparison.
     ASSERT_EQ(1, values_.size());
     EXPECT_EQ("false", values_.top());
 
@@ -1569,7 +1569,7 @@ TEST_F(TokenTest, optionEqualTrue) {
     EXPECT_NO_THROW(t_->evaluate(*pkt4_, values_));
 
     // After evaluation there should be a single value that represents
-    // result of "foo" == "foo" comparision.
+    // result of "foo" == "foo" comparison.
     ASSERT_EQ(1, values_.size());
     EXPECT_EQ("true", values_.top());
 
@@ -2026,7 +2026,7 @@ TEST_F(TokenTest, operatorAndTrue) {
 }
 
 // This test checks if a token representing an or is able to
-// combinate two values (with incorrectly built stack).
+// combine two values (with incorrectly built stack).
 TEST_F(TokenTest, operatorOrInvalid) {
 
     ASSERT_NO_THROW(t_.reset(new TokenOr()));
@@ -2134,7 +2134,7 @@ TEST_F(TokenTest, vendor6SpecificVendorExists) {
     // Case 2: option present, but uses different enterprise-id, should fail
     testVendorExists(Option::V6, 4491, 1234, "false");
 
-    // Case 3: option present and has matchin enterprise-id, should suceed
+    // Case 3: option present and has matchin enterprise-id, should succeed
     testVendorExists(Option::V6, 4491, 4491, "true");
 
     // Check if the logged messages are correct.

--- a/src/lib/eval/token.h
+++ b/src/lib/eval/token.h
@@ -342,7 +342,7 @@ protected:
 class TokenRelay6Option : public TokenOption {
 public:
     /// @brief Constructor that takes a nesting level and an option
-    /// code as paramaters.
+    /// code as parameters.
     ///
     /// @param nest_level the nesting for which relay to examine.
     /// @param option_code code of the option.
@@ -398,10 +398,10 @@ public:
 
     /// @brief Gets a value from the specified packet.
     ///
-    /// Evaluation uses metadatas available in the packet. It does not
+    /// Evaluation uses metadata available in the packet. It does not
     /// require any values to be present on the stack.
     ///
-    /// @param pkt - metadatas will be extracted from here
+    /// @param pkt - metadata will be extracted from here
     /// @param values - stack of values (1 result will be pushed)
     void evaluate(Pkt& pkt, ValueStack& values);
 
@@ -499,7 +499,7 @@ public:
 
     /// @brief Gets a value of the specified packet.
     ///
-    /// The evaluation uses fields that are availabe in the packet.  It does not
+    /// The evaluation uses fields that are available in the packet.  It does not
     /// require any values to be present on the stack.
     ///
     /// @throw EvalTypeError when called for a DHCPv4 packet

--- a/src/lib/exceptions/exceptions.h
+++ b/src/lib/exceptions/exceptions.h
@@ -64,7 +64,7 @@ public:
     /// @return A C-style character string of the exception cause.
     virtual const char* what() const throw();
 
-    /// \brief Returns a C-style charater string of the cause of exception.
+    /// \brief Returns a C-style character string of the cause of exception.
     ///
     /// With verbose set to true, also returns file name and line numbers.
     /// Note that we can't simply define a single what() method with parameters,
@@ -241,6 +241,6 @@ public:
 }
 #endif // EXCEPTIONS_H
 
-// Local Variables: 
+// Local Variables:
 // mode: c++
-// End: 
+// End:

--- a/src/lib/hooks/callout_manager.cc
+++ b/src/lib/hooks/callout_manager.cc
@@ -184,7 +184,7 @@ CalloutManager::callCallouts(int hook_index, CalloutHandle& callout_handle) {
             .arg(server_hooks_.getName(current_hook_))
             .arg(stopwatch.logFormatTotalDuration());
 
-        // Reset the current hook and library indexs to an invalid value to
+        // Reset the current hook and library indices to an invalid value to
         // catch any programming errors.
         current_hook_ = -1;
         current_library_ = -1;

--- a/src/lib/hooks/library_handle.h
+++ b/src/lib/hooks/library_handle.h
@@ -135,10 +135,10 @@ public:
     ///    }
     ///]
     ///
-    /// The first library has no parameters, so regardles of the name
+    /// The first library has no parameters, so regardless of the name
     /// specified, for that library getParameter will always return NULL.
     ///
-    /// For the second paramter, depending the following calls will return:
+    /// For the second parameter, depending the following calls will return:
     /// - x = getParameter("mail") will return instance of
     ///   isc::data::StringElement. The content can be accessed with
     ///   x->stringValue() and will return std::string.

--- a/src/lib/hooks/library_manager_collection.h
+++ b/src/lib/hooks/library_manager_collection.h
@@ -98,7 +98,7 @@ public:
     ///
     /// Returns a callout manager that can be used with this set of loaded
     /// libraries (even if the number of loaded libraries is zero).  This
-    /// method may only be caslled after loadLibraries() has been called.
+    /// method may only be called after loadLibraries() has been called.
     ///
     /// @return Pointer to a callout manager for this set of libraries.
     ///

--- a/src/lib/hooks/tests/hooks_manager_unittest.cc
+++ b/src/lib/hooks/tests/hooks_manager_unittest.cc
@@ -542,7 +542,7 @@ TEST_F(HooksManagerTest, validateLibraries) {
 // This test verifies that the specified parameters are accessed properly.
 TEST_F(HooksManagerTest, LibraryParameters) {
 
-    // Prepare paramters for the callout parameters library.
+    // Prepare parameters for the callout parameters library.
     ElementPtr params = Element::createMap();
     params->set("svalue", Element::create("string value"));
     params->set("ivalue", Element::create(42));

--- a/src/lib/hooks/tests/library_manager_unittest.cc
+++ b/src/lib/hooks/tests/library_manager_unittest.cc
@@ -572,7 +572,7 @@ TEST_F(LibraryManagerTest, libraryLoggerSetup) {
     EXPECT_TRUE(lib_manager.loadLibrary());
 
     // After loading the library, the global logging dictionary should
-    // contain log messages registerd for this library.
+    // contain log messages registered for this library.
     const MessageDictionaryPtr& dict = MessageDictionary::globalDictionary();
     EXPECT_EQ("basic callout load %1", dict->getText("BCL_LOAD_START"));
     EXPECT_EQ("basic callout load end", dict->getText("BCL_LOAD_END"));

--- a/src/lib/log/interprocess/tests/run_unittests.cc
+++ b/src/lib/log/interprocess/tests/run_unittests.cc
@@ -8,7 +8,7 @@
 #include <util/unittests/run_all.h>
 #include <stdlib.h>
 
-// This file uses TEST_DATA_TOPBUILDDIR macro, which must point to a writeable
+// This file uses TEST_DATA_TOPBUILDDIR macro, which must point to a writable
 // directory. It will be used for creating a logger lockfile.
 
 int

--- a/src/lib/log/log_messages.cc
+++ b/src/lib/log/log_messages.cc
@@ -52,7 +52,7 @@ const char* values[] = {
     "LOG_PREFIX_INVALID_ARG", "line %1: $PREFIX directive has an invalid argument ('%2')",
     "LOG_READING_LOCAL_FILE", "reading local message file %1",
     "LOG_READ_ERROR", "error reading from message file %1: %2",
-    "LOG_UNRECOGNIZED_DIRECTIVE", "line %1: unrecogniszd directive '%2'",
+    "LOG_UNRECOGNIZED_DIRECTIVE", "line %1: unrecognized directive '%2'",
     "LOG_WRITE_ERROR", "error writing to %1: %2",
     NULL
 };

--- a/src/lib/log/message_initializer.h
+++ b/src/lib/log/message_initializer.h
@@ -59,7 +59,7 @@ typedef boost::shared_ptr<LoggerDuplicatesList> LoggerDuplicatesListPtr;
 /// To avoid static initialization fiasco problems, the containers shared by
 /// all instances of this class are dynamically allocated on first use, and
 /// held in the smart pointers which are de-allocated only when all instances
-/// of the class are destructred. After the object has been created with the
+/// of the class are destructed. After the object has been created with the
 /// constructor, the \c MessageInitializer::loadDictionary static function is
 /// called to populate the messages defined in various instances of the
 /// \c MessageInitializer class to the global dictionary.

--- a/src/lib/log/tests/logger_example.cc
+++ b/src/lib/log/tests/logger_example.cc
@@ -118,7 +118,7 @@ int main(int argc, char** argv) {
 
     // In the parsing loop that follows, the construction of the logging
     // specification is always "one behind".  In other words, the parsing of
-    // command-line options updates thge current logging specification/output
+    // command-line options updates the current logging specification/output
     // options.  When the flag indicating a new logger or output specification
     // is encountered, the previous one is added to the list.
     //

--- a/src/lib/log/tests/logger_manager_unittest.cc
+++ b/src/lib/log/tests/logger_manager_unittest.cc
@@ -110,7 +110,7 @@ public:
     static std::string createTempFilename() {
         string filename = TEMP_DIR + "/kea_logger_manager_test_XXXXXX";
 
-        // Copy into writeable storage for the call to mkstemp
+        // Copy into writable storage for the call to mkstemp
         boost::scoped_array<char> tname(new char[filename.size() + 1]);
         strcpy(tname.get(), filename.c_str());
 

--- a/src/lib/process/d_cfg_mgr.h
+++ b/src/lib/process/d_cfg_mgr.h
@@ -363,7 +363,7 @@ protected:
     /// @return Returns a DCfgContextBasePtr to the new context instance.
     virtual DCfgContextBasePtr createNewContext() = 0;
 
-    /// @brief Replaces existing context with a new, emtpy context.
+    /// @brief Replaces existing context with a new, empty context.
     void resetContext();
 
     /// @brief Update the current context.

--- a/src/lib/process/d_controller.h
+++ b/src/lib/process/d_controller.h
@@ -113,7 +113,7 @@ public:
     /// @brief returns Kea version on stdout and exit.
     /// redeclaration/redefinition. @ref isc::dhcp::Daemon::getVersion()
     static std::string getVersion(bool extended);
- 
+
     /// @brief Acts as the primary entry point into the controller execution
     /// and provides the outermost application control logic:
     ///
@@ -179,7 +179,7 @@ public:
     ///
     /// The method extracts the set of configuration elements for the
     /// module-name which matches the controller's app_name_ and passes that
-    /// set into @c udpateConfig().
+    /// set into @c updateConfig().
     ///
     /// The file may contain an arbitrary number of other modules.
     ///

--- a/src/lib/process/io_service_signal.h
+++ b/src/lib/process/io_service_signal.h
@@ -68,7 +68,7 @@ typedef boost::function<void(IOSignalId sequence_id)> IOSignalHandler;
 /// pointer to instigating IOSignal from which the value of OS signal (i.e.
 /// SIGINT, SIGUSR1...) can be obtained.  Note that calling popSignal()
 /// removes the IOSignalPtr from the queue, which should reduce its
-/// reference count to zero upon exiting the handler (unless a delibrate
+/// reference count to zero upon exiting the handler (unless a deliberate
 /// copy of it is made).
 ///
 /// A typical IOSignalHandler might be structured as follows:
@@ -190,7 +190,7 @@ typedef std::map<IOSignalId, IOSignalPtr> IOSignalMap;
 /// This class is designed specifically to make managing them painless.
 /// It maintains an internal map of IOSignals keyed by sequence_id. When a
 /// signal is created via the pushSignal() method it is added to the map. When
-/// a signal is retrevied via the popSignal() method it is removed from the map.
+/// a signal is retrieved via the popSignal() method it is removed from the map.
 class IOSignalQueue {
 public:
     /// @brief Constructor
@@ -211,7 +211,7 @@ public:
     /// control to IOService::run()).
     ///
     /// @param signum OS signal value of the signal to propagate
-    /// @param handler IOSignalHandler to invoke when the signal is delivererd.
+    /// @param handler IOSignalHandler to invoke when the signal is delivered.
     ///
     /// @return The sequence_id of the newly created signal.
     ///
@@ -231,7 +231,7 @@ public:
     ///
     /// @throw IOSignalError if there is no matching IOSignal in the map for
     /// the given sequence_id.  Other than by doubling popping, this should be
-    /// very unlikley.
+    /// very unlikely.
     IOSignalPtr popSignal(IOSignalId sequence_id);
 
     /// @brief Erases the contents of the queue.

--- a/src/lib/process/tests/d_controller_unittests.cc
+++ b/src/lib/process/tests/d_controller_unittests.cc
@@ -189,7 +189,7 @@ TEST_F(DStubControllerTest, launchNormalShutdown) {
 }
 
 /// @brief Tests launch with an non-existing configuration file.
-TEST_F(DStubControllerTest, non-existingConfigFile) {
+TEST_F(DStubControllerTest, nonExistingConfigFile) {
     // command line to run standalone
     char* argv[] = { const_cast<char*>("progName"),
                      const_cast<char*>("-c"),

--- a/src/lib/process/tests/d_controller_unittests.cc
+++ b/src/lib/process/tests/d_controller_unittests.cc
@@ -38,7 +38,7 @@ public:
 };
 
 /// @brief Basic Controller instantiation testing.
-/// Verfies that the controller singleton gets created and that the
+/// Verifies that the controller singleton gets created and that the
 /// basic derivation from the base class is intact.
 TEST_F(DStubControllerTest, basicInstanceTesting) {
     // Verify that the singleton exists and it is the correct type.
@@ -188,8 +188,8 @@ TEST_F(DStubControllerTest, launchNormalShutdown) {
                 elapsed_time.total_milliseconds() <= 2300);
 }
 
-/// @brief Tests launch with an nonexistant configuration file.
-TEST_F(DStubControllerTest, nonexistantConfigFile) {
+/// @brief Tests launch with an non-existing configuration file.
+TEST_F(DStubControllerTest, non-existingConfigFile) {
     // command line to run standalone
     char* argv[] = { const_cast<char*>("progName"),
                      const_cast<char*>("-c"),

--- a/src/lib/process/tests/io_service_signal_unittests.cc
+++ b/src/lib/process/tests/io_service_signal_unittests.cc
@@ -20,7 +20,7 @@ namespace process {
 /// @brief Test fixture for testing the use of IOSignals.
 ///
 /// This fixture is exercises IOSignaling as it is intended to be used in
-/// an application in conjuction with util::SignalSet.
+/// an application in conjunction with util::SignalSet.
 class IOSignalTest : public ::testing::Test {
 public:
     /// @brief IOService instance to process IO.
@@ -126,7 +126,7 @@ public:
     }
 };
 
-// Used for constuctor tests.
+// Used for constructor tests.
 void dummyHandler(IOSignalId) {
 }
 
@@ -241,7 +241,7 @@ TEST_F(IOSignalTest, singleSignalTest) {
     // Use TimedSignal to generate SIGINT 100 ms after we start IOService::run.
     TimedSignal sig_int(*io_service_, SIGINT, 100);
 
-    // The first handler executed is the IOSignal's internal timer expirey
+    // The first handler executed is the IOSignal's internal timer expire
     // callback.
     io_service_->run_one();
 
@@ -356,8 +356,8 @@ TEST_F(IOSignalTest, mixedSignals) {
     // Verify we received the expected number of signals.
     ASSERT_EQ(stop_at_count_, processed_signals_.size());
 
-    // There is no gaurantee that the signals will always be delivered in the
-    // order they are raised, but all of them should get delievered.  Loop
+    // There is no guarantee that the signals will always be delivered in the
+    // order they are raised, but all of them should get delivered.  Loop
     // through and tally them up.
     int sigint_cnt = 0;
     int sigusr1_cnt = 0;

--- a/src/lib/process/testutils/d_test_stubs.cc
+++ b/src/lib/process/testutils/d_test_stubs.cc
@@ -273,7 +273,7 @@ DControllerTest::runWithConfig(const std::string& config, int run_time_ms,
                          const_cast<char*>("-d") };
         launch(4, argv);
     } catch (...) {
-        // calculate elasped time, then rethrow it
+        // calculate elapsed time, then rethrow it
         elapsed_time = microsec_clock::universal_time() - start;
         throw;
     }

--- a/src/lib/process/testutils/d_test_stubs.h
+++ b/src/lib/process/testutils/d_test_stubs.h
@@ -488,7 +488,7 @@ public:
     ///
     /// @code
     ///    { "<app_name>" : <content> }
-    /// @endcod
+    /// @endcode
     ///
     /// suffix the content within a JSON element with the given module
     /// name or  wrapped by a JSON
@@ -513,7 +513,7 @@ public:
     /// file to replaced write_time_ms after DControllerBase::launch() has
     /// invoked runProcess().
     ///
-    /// @param config JSON string containing the deisred content for the config
+    /// @param config JSON string containing the desired content for the config
     /// file.
     /// @param write_time_ms time in milliseconds to delay before writing the
     /// file.

--- a/src/lib/stats/stats_mgr.cc
+++ b/src/lib/stats/stats_mgr.cc
@@ -59,19 +59,19 @@ void StatsMgr::addValue(const std::string& name, const std::string& value) {
 
 ObservationPtr StatsMgr::getObservation(const std::string& name) const {
     /// @todo: Implement contexts.
-    // Currently we keep everyting in a global context.
+    // Currently we keep everything in a global context.
     return (global_->get(name));
 }
 
 void StatsMgr::addObservation(const ObservationPtr& stat) {
     /// @todo: Implement contexts.
-    // Currently we keep everyting in a global context.
+    // Currently we keep everything in a global context.
     return (global_->add(stat));
 }
 
 bool StatsMgr::deleteObservation(const std::string& name) {
     /// @todo: Implement contexts.
-    // Currently we keep everyting in a global context.
+    // Currently we keep everything in a global context.
     return (global_->del(name));
 }
 

--- a/src/lib/stats/stats_mgr.h
+++ b/src/lib/stats/stats_mgr.h
@@ -28,7 +28,7 @@ namespace stats {
 /// As of May 2015, Tomek ran performance benchmarks (see unit-tests in
 /// stats_mgr_unittest.cc with performance in their names) and it seems
 /// the code is able to register ~2.5-3 million observations per second, even
-/// with 1000 different statistics recored. That seems sufficient for now,
+/// with 1000 different statistics recorded. That seems sufficient for now,
 /// so there is no immediate need to develop any multi-threading solutions
 /// for now. However, should this decision be revised in the future, the
 /// best place for it would to be modify @ref addObservation method here.
@@ -47,7 +47,7 @@ namespace stats {
 ///   significantly. While it's possible to log on sufficiently high debug
 ///   level, such a log would be not that useful)
 /// - dependency (statistics are intended to be a lightweight library, adding
-///   dependency on libkea-log, which has its own dependecies, including
+///   dependency on libkea-log, which has its own dependencies, including
 ///   external log4cplus, is against 'lightweight' design)
 /// - if logging of specific statistics is warranted, it is recommended to
 ///   add log entries in the code that calls StatsMgr.

--- a/src/lib/stats/tests/observation_unittest.cc
+++ b/src/lib/stats/tests/observation_unittest.cc
@@ -46,7 +46,7 @@ public:
     Observation d;
 };
 
-// Basic tests for the Obseration constructors. This test checks whether
+// Basic tests for the Observation constructors. This test checks whether
 // parameters passed to the constructor initialize the object properly.
 TEST_F(ObservationTest, constructor) {
 
@@ -139,7 +139,7 @@ TEST_F(ObservationTest, timers) {
     ptime before = microsec_clock::local_time();
     b.setValue(123.0); // Set it to a random value and record the time.
 
-    // Allow a bit of inprecision. This test allows 50ms. That should be ok,
+    // Allow a bit of imprecision. This test allows 50ms. That should be ok,
     // when running on virtual machines.
     ptime after = before + millisec::time_duration(0,0,0,50);
 

--- a/src/lib/stats/tests/stats_mgr_unittest.cc
+++ b/src/lib/stats/tests/stats_mgr_unittest.cc
@@ -453,7 +453,7 @@ TEST_F(StatsMgrTest, commandStatisticGetNegative) {
     EXPECT_EQ("{ \"arguments\": {  }, \"result\": 0 }", rsp->str());
 }
 
-// This test checks whether statistc-get-all command returns all statistics
+// This test checks whether statistic-get-all command returns all statistics
 // correctly.
 TEST_F(StatsMgrTest, commandGetAll) {
 

--- a/src/lib/testutils/dhcp_test_lib.sh.in
+++ b/src/lib/testutils/dhcp_test_lib.sh.in
@@ -174,7 +174,7 @@ fi
 # This function uses PID file to obtain the PID and then calls
 # 'kill -0 <pid>' to check if the process is alive.
 # The PID files are expected to be located in the ${PID_FILE_PATH},
-# and their names should match the follwing pattern:
+# and their names should match the following pattern:
 # <cfg_file_name>.<proc_name>.pid. If the <cfg_file_name> is not
 # specified a 'test_config' is used by default.
 #
@@ -261,8 +261,8 @@ get_log_messages() {
 #   _GET_RECONFIGS: number of configurations so far.
 #   _GET_RECONFIG_ERRORS: number of configuration errors.
 get_reconfigs() {
-    # Grep log file for CONFIG_COMPLETE occurences. There should
-    # be one occurence per (re)configuration.
+    # Grep log file for CONFIG_COMPLETE occurrences. There should
+    # be one occurrence per (re)configuration.
     _GET_RECONFIGS=$( grep -o CONFIG_COMPLETE ${LOG_FILE} | wc -w )
     # Grep log file for CONFIG_LOAD_FAIL to check for configuration
     # failures.
@@ -318,7 +318,7 @@ cleanup() {
 }
 
 # Exists the test in the clean way.
-# It peformes the cleanup and prints whether the test has passed or failed.
+# It performs the cleanup and prints whether the test has passed or failed.
 # If a test fails, the Kea log is dumped.
 clean_exit() {
     exit_code=${1}  # Exit code to be returned by the exit function.
@@ -384,7 +384,7 @@ wait_for_kea() {
 # of message occurrences to show up. If the expected number of
 # message doesn't occur, the error status is returned.
 # Return value:
-#    _WAIT_FOR_MESSAGE: 0 if the message hasn't occured, 1 otherwise.
+#    _WAIT_FOR_MESSAGE: 0 if the message hasn't occurred, 1 otherwise.
 wait_for_message() {
     local timeout=${1}     # Expected timeout value in seconds.
     local message="${2}"   # Expected message id.
@@ -435,7 +435,7 @@ must be a number"
 
 # Waits for server to be down.
 # Return value:
-#    _WAIT_FOR_SERVER_DOWN: 1 if server is down, 0 if timeout occured and the
+#    _WAIT_FOR_SERVER_DOWN: 1 if server is down, 0 if timeout occurred and the
 #                             server is still running.
 wait_for_server_down() {
     local timeout=${1}    # Timeout specified in seconds.

--- a/src/lib/util/csv_file.h
+++ b/src/lib/util/csv_file.h
@@ -391,7 +391,7 @@ public:
     /// true, the file will be opened and the internal pointer will be set
     /// to the end of file.
     ///
-    /// @param seek_to_end A boolean value which indicates if the intput and
+    /// @param seek_to_end A boolean value which indicates if the input and
     /// output file pointer should be set at the end of file.
     ///
     /// @throw CSVFileError when IO operation fails.

--- a/src/lib/util/range_utilities.h
+++ b/src/lib/util/range_utilities.h
@@ -39,7 +39,7 @@ isRangeZero(Iterator begin, Iterator end) {
 /// after every start of your process.  Calling srand() is enough. This
 /// method uses default rand(), which is usually a LCG pseudo-random
 /// number generator, so it is not suitable for security
-/// purposes. Please get a decent PRNG implementation, like Mersene
+/// purposes. Please get a decent PRNG implementation, like Mersenne
 /// twister, if you are doing anything related with security.
 ///
 /// PRNG initialization is left out of this function on purpose. It may

--- a/src/lib/util/state_model.cc
+++ b/src/lib/util/state_model.cc
@@ -84,7 +84,7 @@ StateModel::~StateModel(){
 
 void
 StateModel::startModel(const int start_state) {
-    // Intialize dictionaries of events and states.
+    // Initialize dictionaries of events and states.
     initDictionaries();
 
     // Set the current state to starting state and enter the run loop.
@@ -232,7 +232,7 @@ StateModel::verifyStates() {
     getState(END_ST);
 }
 
-void 
+void
 StateModel::onModelFailure(const std::string&) {
     // Empty implementation to make deriving classes simpler.
 }

--- a/src/lib/util/state_model.h
+++ b/src/lib/util/state_model.h
@@ -90,7 +90,7 @@ public:
     /// @brief Adds a state definition to the set of states.
     ///
     /// @param value is the numeric value of the state
-    /// @param label is the text label to assig to the state
+    /// @param label is the text label to assign to the state
     /// @param handler is the bound instance method which handles the state's
     ///
     /// @throw StateModelError if the value is already defined in the set, or
@@ -265,7 +265,7 @@ public:
     /// @brief Begins execution of the model.
     ///
     /// This method invokes initDictionaries method to initialize the event
-    /// and state dictionaries and then starts the model execution setting 
+    /// and state dictionaries and then starts the model execution setting
     /// the current state to the given start state, and the event to START_EVT.
     ///
     /// @param start_state is the state in which to begin execution.
@@ -314,7 +314,7 @@ protected:
     /// @brief Initializes the event and state dictionaries.
     ///
     /// This method invokes the define and verify methods for both events and
-    /// states to initialize their respective dictionaries. 
+    /// states to initialize their respective dictionaries.
     ///
     /// @throw StateModelError or others indirectly, as this method calls
     /// dictionary define and verify methods.

--- a/src/lib/util/stopwatch_impl.h
+++ b/src/lib/util/stopwatch_impl.h
@@ -93,7 +93,7 @@ protected:
     ///
     /// This method is used internally by the @c StopwatchImpl class and
     /// its derivations. This class simply returns the value of
-    /// @c boost::posix_time::micrisec_clock::univeral_time(), which is
+    /// @c boost::posix_time::microsec_clock::univeral_time(), which is
     /// a current timestamp. The derivations may replace it with the
     /// custom implementations. The typical use case is for the unit tests
     /// to customize the behavior of this function to return well known

--- a/src/lib/util/tests/csv_file_unittest.cc
+++ b/src/lib/util/tests/csv_file_unittest.cc
@@ -122,7 +122,7 @@ TEST(CSVRow, trim) {
     EXPECT_EQ("two", row.readAt(2));
     EXPECT_EQ("three", row.readAt(3));
 
-    // Verfiy we can trim more than one
+    // Verify we can trim more than one
     ASSERT_NO_THROW(row.trim(2));
     ASSERT_EQ(2, row.getValuesCount());
     EXPECT_EQ("zero", row.readAt(0));

--- a/src/lib/util/tests/process_spawn_unittest.cc
+++ b/src/lib/util/tests/process_spawn_unittest.cc
@@ -67,7 +67,7 @@ bool waitForProcess(const ProcessSpawn& process, const pid_t pid,
 ///
 /// This method does not use any sleep() calls, but rather iterates through
 /// the loop very fast. This is not recommended in general, but is necessary
-/// to avoid updating errno by sleep() after receving a signal.
+/// to avoid updating errno by sleep() after receiving a signal.
 ///
 /// Note: the timeout is only loosely accurate. Depending on the fraction
 /// of second it was started on, it may terminate later by up to almost

--- a/src/lib/util/tests/staged_value_unittest.cc
+++ b/src/lib/util/tests/staged_value_unittest.cc
@@ -15,7 +15,7 @@ using namespace isc::util;
 
 // This test verifies that the value can be assigned and committed.
 TEST(StagedValueTest, assignAndCommit) {
-    // Initally the value should be set to a default
+    // Initially the value should be set to a default
     StagedValue<int> value;
     ASSERT_EQ(0, value.getValue());
 

--- a/src/lib/util/tests/stopwatch_unittest.cc
+++ b/src/lib/util/tests/stopwatch_unittest.cc
@@ -59,7 +59,7 @@ public:
 
 protected:
 
-    /// @brief Returs the current time.
+    /// @brief Returns the current time.
     ///
     /// This method returns the fixed @c current_time_ timestamp.
     virtual ptime getCurrentTime() const;

--- a/src/lib/util/tests/strutil_unittest.cc
+++ b/src/lib/util/tests/strutil_unittest.cc
@@ -405,7 +405,7 @@ TEST(StringUtilTest, decodeFormattedHexString) {
     testFormatted("", "");
 
     std::vector<uint8_t> decoded;
-    // Whitepspace.
+    // Whitespace.
     EXPECT_THROW(decodeFormattedHexString("0a ", decoded),
                  isc::BadValue);
     // Whitespace within a string.

--- a/src/lib/util/tests/versioned_csv_file_unittest.cc
+++ b/src/lib/util/tests/versioned_csv_file_unittest.cc
@@ -148,7 +148,7 @@ TEST_F(VersionedCSVFileTest, addColumn) {
     // We should have 3 defined columns
     // Input Header should match defined columns on new files
     // Valid columns should match defined columns on new files
-    // Minium valid columns wasn't set. (Remember it's optional)
+    // Minimum valid columns wasn't set. (Remember it's optional)
     EXPECT_EQ(3, csv->getColumnCount());
     EXPECT_EQ(3, csv->getInputHeaderCount());
     EXPECT_EQ(3, csv->getValidColumnCount());
@@ -193,7 +193,7 @@ TEST_F(VersionedCSVFileTest, currentSchemaTest) {
     // 3 defined columns
     // 3 columns total found in the header
     // 3 valid columns found in the header
-    // Minium valid columns wasn't set. (Remember it's optional)
+    // Minimum valid columns wasn't set. (Remember it's optional)
     EXPECT_EQ(3, csv->getColumnCount());
     EXPECT_EQ(3, csv->getInputHeaderCount());
     EXPECT_EQ(3, csv->getValidColumnCount());
@@ -252,7 +252,7 @@ TEST_F(VersionedCSVFileTest, upgradeOlderVersions) {
     // 2 defined columns
     // 1 column found in the header
     // 1 valid column in the header
-    // Minium valid columns wasn't set. (Remember it's optional)
+    // Minimum valid columns wasn't set. (Remember it's optional)
     EXPECT_EQ(2, csv->getColumnCount());
     EXPECT_EQ(1, csv->getInputHeaderCount());
     EXPECT_EQ(1, csv->getValidColumnCount());
@@ -312,7 +312,7 @@ TEST_F(VersionedCSVFileTest, upgradeOlderVersions) {
     // 3 defined columns
     // 1 column found in the header
     // 1 valid column in the header
-    // Minium valid columns wasn't set. (Remember it's optional)
+    // Minimum valid columns wasn't set. (Remember it's optional)
     EXPECT_EQ(3, csv->getColumnCount());
     EXPECT_EQ(1, csv->getInputHeaderCount());
     EXPECT_EQ(1, csv->getValidColumnCount());
@@ -432,7 +432,7 @@ TEST_F(VersionedCSVFileTest, downGrading) {
     // 2 defined columns
     // 3 columns found in the header
     // 2 valid columns in the header
-    // Minium valid columns wasn't set. (Remember it's optional)
+    // Minimum valid columns wasn't set. (Remember it's optional)
     EXPECT_EQ(2, csv->getColumnCount());
     EXPECT_EQ(3, csv->getInputHeaderCount());
     EXPECT_EQ(2, csv->getValidColumnCount());

--- a/src/lib/util/threads/tests/run_unittests.cc
+++ b/src/lib/util/threads/tests/run_unittests.cc
@@ -8,7 +8,7 @@
 #include <util/unittests/run_all.h>
 #include <stdlib.h>
 
-// This file uses TEST_DATA_TOPBUILDDIR macro, which must point to a writeable
+// This file uses TEST_DATA_TOPBUILDDIR macro, which must point to a writable
 // directory. It will be used for creating a logger lockfile.
 
 int

--- a/src/lib/util/versioned_csv_file.h
+++ b/src/lib/util/versioned_csv_file.h
@@ -171,7 +171,7 @@ public:
     /// @brief Returns the number of valid columns found in the header
     /// For newly created files this will always match the number of defined
     /// columns (i.e. getColumnCount()).  For existing files, this will be
-    /// the number of columns in the header that match the defined columnns.
+    /// the number of columns in the header that match the defined columns.
     /// When this number is less than getColumnCount() it means the input file
     /// is from an earlier schema.  This value is zero until the file has
     /// been opened.
@@ -189,7 +189,7 @@ public:
     /// true, the file will be opened and the internal pointer will be set
     /// to the end of file.
     ///
-    /// @param seek_to_end A boolean value which indicates if the intput and
+    /// @param seek_to_end A boolean value which indicates if the input and
     /// output file pointer should be set at the end of file.
     ///
     /// @throw VersionedCSVFileError if schema has not been defined,

--- a/src/lib/util/watch_socket.cc
+++ b/src/lib/util/watch_socket.cc
@@ -131,7 +131,7 @@ WatchSocket::closeSocket(std::string& error_string) {
     // destructors that throw.
     if (source_ != SOCKET_NOT_VALID) {
         if (close(source_)) {
-            // An error occured.
+            // An error occurred.
             s << "Could not close source: " << strerror(errno);
         }
 
@@ -140,7 +140,7 @@ WatchSocket::closeSocket(std::string& error_string) {
 
     if (sink_ != SOCKET_NOT_VALID) {
         if (close(sink_)) {
-            // An error occured.
+            // An error occurred.
             if (error_string.empty()) {
                 s << "could not close sink: " << strerror(errno);
             }

--- a/src/share/database/scripts/mysql/dhcpdb_create.mysql
+++ b/src/share/database/scripts/mysql/dhcpdb_create.mysql
@@ -402,7 +402,7 @@ DROP INDEX key_dhcp6_identifier_subnet_id ON hosts;
 CREATE UNIQUE INDEX key_dhcp6_identifier_subnet_id ON hosts (dhcp_identifier ASC , dhcp_identifier_type ASC , dhcp6_subnet_id ASC);
 
 # Create index to search for reservations using IP address and subnet id.
-# This unique index guarantees that there is only one occurence of the
+# This unique index guarantees that there is only one occurrence of the
 # particular IPv4 address for a given subnet.
 CREATE UNIQUE INDEX key_dhcp4_ipv4_address_subnet_id ON hosts (ipv4_address ASC , dhcp4_subnet_id ASC);
 

--- a/src/share/database/scripts/mysql/upgrade_4.1_to_5.0.sh.in
+++ b/src/share/database/scripts/mysql/upgrade_4.1_to_5.0.sh.in
@@ -29,7 +29,7 @@ DROP INDEX key_dhcp6_identifier_subnet_id ON hosts;
 CREATE UNIQUE INDEX key_dhcp6_identifier_subnet_id ON hosts (dhcp_identifier ASC , dhcp_identifier_type ASC , dhcp6_subnet_id ASC);
 
 # Create index to search for reservations using IP address and subnet id.
-# This unique index guarantees that there is only one occurence of the
+# This unique index guarantees that there is only one occurrence of the
 # particular IPv4 address for a given subnet.
 CREATE UNIQUE INDEX key_dhcp4_ipv4_address_subnet_id ON hosts (ipv4_address ASC , dhcp4_subnet_id ASC);
 

--- a/src/share/database/scripts/pgsql/dhcpdb_create.pgsql
+++ b/src/share/database/scripts/pgsql/dhcpdb_create.pgsql
@@ -261,7 +261,7 @@ INSERT INTO dhcp_option_scope VALUES (3, 'host');
 --
 -- Table structure for table hosts.
 --
--- Primary key and unique contraints automatically create indexes,
+-- Primary key and unique constraints automatically create indexes,
 -- foreign key constraints do not.
 CREATE TABLE hosts (
   host_id SERIAL PRIMARY KEY NOT NULL,

--- a/src/share/database/scripts/pgsql/upgrade_2.0_to_3.0.sh.in
+++ b/src/share/database/scripts/pgsql/upgrade_2.0_to_3.0.sh.in
@@ -47,7 +47,7 @@ INSERT INTO dhcp_option_scope VALUES (3, 'host');
 --
 -- Table structure for table hosts
 --
--- Primary key and unique contraints automatically create indexes
+-- Primary key and unique constraints automatically create indexes
 -- foreign key constraints do not
 CREATE TABLE hosts (
   host_id SERIAL PRIMARY KEY NOT NULL,

--- a/tools/system_messages.cc
+++ b/tools/system_messages.cc
@@ -486,7 +486,7 @@ void processFileContent(const std::string& filename,
         }
     }
 
-    // All done, add the last message to the global dictionaty.
+    // All done, add the last message to the global dictionary.
     if (!msgid.empty()) {
         addToDictionary(msgid, msgtext, description, filename);
     }
@@ -547,7 +547,7 @@ void processFile(const std::string& filename)
         if (line[0] != '#') {
             lines1.push_back(line);
         }
-    }  
+    }
 
     // Remove leading/trailing empty line sequences from the result
     LinesType lines2 = removeEmptyLeadingTrailing(lines1);


### PR DESCRIPTION
The important stuff, right? :)
We've run a spell checker and "indentified" some spelling mistakes.
If you'll review from the command line, we recommend one of the following commands:
git diff --color-words
git diff --color-words | sed -n '/31m/,/m/p'
git diff --color-words --unified=0