### PR TITLE
put dhcp6.h stuff inside isc::dhcp namespace (to fix collisions and for consistency with dhcp4.h)

### DIFF
--- a/src/lib/dhcp/dhcp6.h
+++ b/src/lib/dhcp/dhcp6.h
@@ -13,6 +13,9 @@
 /// add an entry in std_option_defs.h, add a stdOptionDefs6 unit test
 /// in tests/libdhcp++_unittest.cc and update dhcp6-std-options-list in
 /// the dhcp6-srv.xml source file of the user guide.
+//
+namespace isc {
+namespace dhcp {
 
 /* DHCPv6 Option codes: */
 
@@ -296,5 +299,8 @@ extern const int dhcpv6_type_name_max;
 
 /* DHCPv4-query message flags (see RFC7341) */
 #define DHCPV4_QUERY_FLAGS_UNICAST (1 << 23)
+
+} // end of isc::dhcp namespace
+} // end of isc namespace
 
 #endif /* DHCP6_H */


### PR DESCRIPTION
I just found out (while building our internal hook) that stuff in `dhcp6.h` are not declared inside the `isc::dhcp` namespace (which you do in `dhcp4.h`).
This is causing collisions for us, so putting stuff in `isc::dhcp` namespace to resolve the issue, and for consistency with `dhcp4.h`.