### PR TITLE
Fix build against musl

### DIFF
--- a/src/bin/perfdhcp/command_options.cc
+++ b/src/bin/perfdhcp/command_options.cc
@@ -22,6 +22,9 @@
 #include <unistd.h>
 #include <fstream>
 
+#ifdef HAVE_OPTRESET
+extern int optreset;
+#endif
 
 using namespace std;
 using namespace isc;

--- a/src/lib/dhcp/pkt_filter_lpf.cc
+++ b/src/lib/dhcp/pkt_filter_lpf.cc
@@ -12,10 +12,10 @@
 #include <dhcp/protocol_util.h>
 #include <exceptions/exceptions.h>
 #include <fcntl.h>
+#include <net/ethernet.h>
 #include <linux/filter.h>
 #include <linux/if_ether.h>
 #include <linux/if_packet.h>
-#include <net/ethernet.h>
 
 namespace {
 


### PR DESCRIPTION
There were two minor issues when I was trying to build KEA on Alpine Linux.

1. The configure script that checks for the presence of optreset first externs the variable and uses which succeeds.  However the actual KEA source file that uses optreset does not first extern the variable.  The Alpine version of /usr/include/unistd.h does not extern optreset and instead this is done in /usr/include/getopt.h.  I thought it would be better to make the code in command_options.cc match the configure script test so that they pass or fail together.
2.  The <linux/if_ether.h> and <net/ethernet.h> both declare "struct ethhdr" and the version of <linux/if_ether.h> will avoid this if <net/ethernet.h> has been included first.