### PR TITLE
Replace another "test" with "expr".

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ fi
 AC_SUBST(WARNING_GCC_44_STRICT_ALIASING_CFLAG)
 CPPP="$CPP"
 # gcc 5 preprocessor requires -P for checking its output
-if test "$CXX_DUMP_VERSION" \> "5"; then
+if expr "$CXX_DUMP_VERSION" \> "5" > /dev/null; then
        CPPP="$CPP -P"
 fi
 


### PR DESCRIPTION
Error message seen on OpenBSD:
```
./configure[16315]: test: >: unexpected operator/operand
```

Another instance of this problem was fixed previously:
https://github.com/isc-projects/kea/pull/25