### PR TITLE
Relax minimal length checking for DHCPv4/v6 Vendor Class Option

### DIFF
--- a/src/lib/dhcp/option_vendor_class.h
+++ b/src/lib/dhcp/option_vendor_class.h
@@ -175,8 +175,22 @@ private:
     }
 
     /// @brief Returns minimal length of the option for the given universe.
+    ///
+    /// For DHCPv6, The Vendor Class option mandates a 2-byte
+    /// OPTION_VENDOR_CLASS followed by a 2-byte option-len with a 4-byte
+    /// enterprise-number.  While section 22.16 of RFC3315 specifies that the
+    /// information contained within the data area can contain one or more
+    /// opaque fields, the inclusion of the vendor-class-data is not mandatory
+    /// and therefore not factored into the overall possible minimum length.
+    ///
+    /// For DHCPv4, The V-I Vendor Class option mandates a 1-byte option-code
+    /// followed by a 1-byte option-len with a 4-byte enterprise-number.
+    /// While section 3 of RFC3925 specifies that the information contained
+    /// within the per-vendor data area can contain one or more opaque fields,
+    /// the inclusion of the vendor-class-data is not mandatory and therefore
+    /// not factored into the overall possible minimum length.
     uint16_t getMinimalLength() const {
-        return (getUniverse() == Option::V4 ? 7 : 8);
+        return (getUniverse() == Option::V4 ? 4 : 4);
     }
 
     /// @brief Enterprise ID.


### PR DESCRIPTION
Previous commit 22baa11f691e6d9393c21d770ed363ad8c75fc24 and mention (http://kea.isc.org/ticket/3576#comment:10) shifted the minimum length for the Vendor Class option for DHCPv6 from 6->8.

There are plenty of client implementations out there (IP Phones, etc..) that will make use of initially sending Option 124 however only including their respective IANA assigned enterprise-number.  This leads to a minimum size of 4 bytes which results in a failure to parse this option and complete failure of further processing of the client packet

`
2017-10-12 19:51:59.213 DEBUG [kea-dhcp4.bad-packets/31122] DHCP4_PACKET_DROP_0001 failed to parse packet from 0.0.0.0 to 255.255.255.255, received over interface eth0, reason: parsed Vendor Class option data truncated to size 4
`

Now, short of demanding legacy implementations to change their dhcp client stacks - RFC3925 and RFC3315 terminology is fairly loose on the strict requirements for these options.  Both specifications call for the possibility of "one or more" opaque fields to exist within the vendor-class-data and that the overall option-len must be 4 (enterprise-number) + the length of the vendor-class-data however the vendor-class-data may not exist in the overall option.  Even if the vendor-class-data were to exist, it could theoritically carry a vendor-class-len/data-len equal to 0 with no following opaque-data.  This would result in a DHCPv4 minimum length of 5 and a DHCPv6 minimum length of 6 which invalidates the previous commit change for DHCPv6.

So I'm suggesting that either the min length check be relaxed to that in the description of this pull request (which now makes the DHCPv4 and DHCPv6 universe identical) or that it be refactored.  Strict compliance with the RFCs and mandating some data within the vendor-class-data will result in client incompatibility with kea unfortunately.