### PR TITLE
asiolink: fix build with boost 1.66

### DIFF
--- a/src/lib/asiolink/io_acceptor.h
+++ b/src/lib/asiolink/io_acceptor.h
@@ -47,7 +47,11 @@ public:
 
     /// @brief Returns file descriptor of the underlying socket.
     virtual int getNative() const {
+#if BOOST_VERSION < 106600
         return (acceptor_->native());
+#else
+        return (acceptor_->native_handle());
+#endif
     }
 
     /// @brief Opens acceptor socket given the endpoint.

--- a/src/lib/asiolink/io_service.h
+++ b/src/lib/asiolink/io_service.h
@@ -11,7 +11,12 @@
 
 namespace boost {
 namespace asio {
+#if BOOST_VERSION < 106600
     class io_service;
+#else
+    class io_context;
+    typedef io_context io_service;
+#endif
 }
 }
 

--- a/src/lib/asiolink/tcp_socket.h
+++ b/src/lib/asiolink/tcp_socket.h
@@ -75,7 +75,11 @@ public:
 
     /// \brief Return file descriptor of underlying socket
     virtual int getNative() const {
+#if BOOST_VERSION < 106600
         return (socket_.native());
+#else
+        return (socket_.native_handle());
+#endif
     }
 
     /// \brief Return protocol of socket

--- a/src/lib/asiolink/udp_socket.h
+++ b/src/lib/asiolink/udp_socket.h
@@ -61,7 +61,11 @@ public:
 
     /// \brief Return file descriptor of underlying socket
     virtual int getNative() const {
+#if BOOST_VERSION < 106600
         return (socket_.native());
+#else
+        return (socket_.native_handle());
+#endif
     }
 
     /// \brief Return protocol of socket

--- a/src/lib/asiolink/unix_domain_socket.cc
+++ b/src/lib/asiolink/unix_domain_socket.cc
@@ -287,7 +287,11 @@ UnixDomainSocket::UnixDomainSocket(IOService& io_service)
 
 int
 UnixDomainSocket::getNative() const {
+#if BOOST_VERSION < 106600
     return (impl_->socket_.native());
+#else
+    return (impl_->socket_.native_handle());
+#endif
 }
 
 int


### PR DESCRIPTION
- use native_handle() for getting native socket type
- use io_context instead of io_service