### PR TITLE
fix bug in kea-admin causing error on lease-dump

### DIFF
--- a/src/bin/admin/kea-admin.in
+++ b/src/bin/admin/kea-admin.in
@@ -448,7 +448,7 @@ mysql_dump() {
 ### Functions used for dump
 pgsql_dump() {
     # Check the lease type was given
-    if [ $dump_type -eq o ]; then
+    if [ $dump_type -eq 0 ]; then
         log_error "lease-dump: lease type ( -4 or -6 ) needs to be specified"
         usage
         exit 1


### PR DESCRIPTION
There is a typo in kea-admin which causes errors on `kea-admin lease-dump` when using the pgsql backend. This small change fixes the issue.