### PR TITLE
perfdhcp should be able to specify extra options

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright (C) 2009-2017 Internet Systems Consortium, Inc. ("ISC")
+Copyright (C) 2009-2018 Internet Systems Consortium, Inc. ("ISC")
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/doc/devel/contribute.dox
+++ b/doc/devel/contribute.dox
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2013-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/doc/devel/mainpage.dox
+++ b/doc/devel/mainpage.dox
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/bin/dhcp4/dhcp4to6_ipc.cc
+++ b/src/bin/dhcp4/dhcp4to6_ipc.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2015-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2015-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/bin/dhcp4/tests/ctrl_dhcp4_srv_unittest.cc
+++ b/src/bin/dhcp4/tests/ctrl_dhcp4_srv_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/bin/dhcp6/tests/config_parser_unittest.cc
+++ b/src/bin/dhcp6/tests/config_parser_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/bin/dhcp6/tests/kea_controller_unittest.cc
+++ b/src/bin/dhcp6/tests/kea_controller_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/bin/dhcp6/tests/test_libraries.h.in
+++ b/src/bin/dhcp6/tests/test_libraries.h.in
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2015 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2013-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/bin/perfdhcp/command_options.h
+++ b/src/bin/perfdhcp/command_options.h
@@ -9,6 +9,7 @@
 
 #include <boost/noncopyable.hpp>
 
+#include <dhcp/option.h>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -337,6 +338,11 @@ public:
     /// \return wrapped command (start/stop).
     std::string getWrapped() const { return wrapped_; }
 
+    /// @brief Returns extra options to be inserted.
+    ///
+    /// @return container with options
+    const isc::dhcp::OptionCollection& getExtraOpts() const { return extra_opts_; }
+
     /// \brief Returns server name.
     ///
     /// \return server name.
@@ -637,6 +643,9 @@ private:
 
     /// Indicates how many DHCPv6 relay agents are simulated.
     uint8_t v6_relay_encapsulation_level_;
+
+    /// @brief Extra options to be sent in each packet.
+    isc::dhcp::OptionCollection extra_opts_;
 };
 
 }  // namespace perfdhcp

--- a/src/bin/perfdhcp/command_options.h
+++ b/src/bin/perfdhcp/command_options.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/bin/perfdhcp/perfdhcp.xml
+++ b/src/bin/perfdhcp/perfdhcp.xml
@@ -65,6 +65,7 @@
             <arg choice="opt" rep="norepeat"><option>-M <replaceable class="parameter">mac-list-file</replaceable></option></arg>
             <arg choice="opt" rep="norepeat"><option>-n <replaceable class="parameter">num-request</replaceable></option></arg>
             <arg choice="opt" rep="norepeat"><option>-O <replaceable class="parameter">random-offset</replaceable></option></arg>
+            <arg choice="opt" rep="norepeat"><option>-o <replaceable class="parameter">code,hexstring</replaceable></option></arg>
             <arg choice="opt" rep="norepeat"><option>-p <replaceable class="parameter">test-period</replaceable></option></arg>
             <arg choice="opt" rep="norepeat"><option>-P <replaceable class="parameter">preload</replaceable></option></arg>
             <arg choice="opt" rep="norepeat"><option>-r <replaceable class="parameter">rate</replaceable></option></arg>
@@ -411,6 +412,28 @@
                       from this list for every new exchange. In the DHCPv6 case, MAC
                       addresses are used to generate DUID-LLs. This parameter must not be
                       used in conjunction with the -b parameter.
+                    </para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-o <replaceable class="parameter">code,hexstring</replaceable></option></term>
+                <listitem>
+                    <para>
+                      This forces perfdhcp to insert specified extra option (or
+                      options if used several times) into packets being
+                      transmitted. The code specifies option code and the
+                      hexstring is a hexadecimal string that defines the content
+                      of the option. Care should be taken as perfdhcp does not
+                      offer any kind of logic behind those options. They're
+                      simply inserted into packets being sent as is. Be careful
+                      not to insert options that are already inserted. For
+                      example, to insert client class identifier (option code
+                      60) with a string 'docsis', you can use -o
+                      60,646f63736973. The <option>-o</option> may be used
+                      multiple times. It is necessary to specify protocol family
+                      (either <option>-4</option> or <option>-6</option>) before
+                      using <option>-o</option>.
                     </para>
                 </listitem>
             </varlistentry>

--- a/src/bin/perfdhcp/test_control.cc
+++ b/src/bin/perfdhcp/test_control.cc
@@ -1706,6 +1706,9 @@ TestControl::sendDiscover4(const TestControlSocket& socket,
     // Set client identifier
     pkt4->addOption(generateClientId(pkt4->getHWAddr()));
 
+    // Add any extra options that user may have specified.
+    addExtraOpts(pkt4);
+
     pkt4->pack();
     IfaceMgr::instance().send(pkt4);
     if (!preload) {
@@ -1784,6 +1787,10 @@ TestControl::sendRequestFromAck(const TestControlSocket& socket) {
     // Create message of the specified type.
     Pkt4Ptr msg = createRequestFromAck(ack);
     setDefaults4(socket, msg);
+
+    // Add any extra options that user may have specified.
+    addExtraOpts(msg);
+
     msg->pack();
     // And send it.
     IfaceMgr::instance().send(msg);
@@ -1817,6 +1824,10 @@ TestControl::sendMessageFromReply(const uint16_t msg_type,
     // Prepare the message of the specified type.
     Pkt6Ptr msg = createMessageFromReply(msg_type, reply);
     setDefaults6(socket, msg);
+
+    // Add any extra options that user may have specified.
+    addExtraOpts(msg);
+
     msg->pack();
     // And send it.
     IfaceMgr::instance().send(msg);
@@ -1873,6 +1884,9 @@ TestControl::sendRequest4(const TestControlSocket& socket,
     // Set client's and server's ports as well as server's address,
     // and local (relay) address.
     setDefaults4(socket, pkt4);
+
+    // Add any extra options that user may have specified.
+    addExtraOpts(pkt4);
 
     // Set hardware address
     pkt4->setHWAddr(offer_pkt4->getHWAddr());
@@ -1989,6 +2003,10 @@ TestControl::sendRequest4(const TestControlSocket& socket,
     pkt4->addOption(opt_requested_ip);
 
     setDefaults4(socket, boost::static_pointer_cast<Pkt4>(pkt4));
+
+    // Add any extra options that user may have specified.
+    addExtraOpts(pkt4);
+
     // Prepare on-wire data.
     pkt4->rawPack();
     IfaceMgr::instance().send(boost::static_pointer_cast<Pkt4>(pkt4));
@@ -2044,6 +2062,10 @@ TestControl::sendRequest6(const TestControlSocket& socket,
 
     // Set default packet data.
     setDefaults6(socket, pkt6);
+
+    // Add any extra options that user may have specified.
+    addExtraOpts(pkt6);
+
     // Prepare on-wire data.
     pkt6->pack();
     IfaceMgr::instance().send(pkt6);
@@ -2148,6 +2170,10 @@ TestControl::sendRequest6(const TestControlSocket& socket,
     pkt6->addOption(opt_clientid);
     // Set default packet data.
     setDefaults6(socket, pkt6);
+
+    // Add any extra options that user may have specified.
+    addExtraOpts(pkt6);
+
     // Prepare on wire data.
     pkt6->rawPack();
     // Send packet.
@@ -2205,6 +2231,10 @@ TestControl::sendSolicit6(const TestControlSocket& socket,
     }
 
     setDefaults6(socket, pkt6);
+
+    // Add any extra options that user may have specified.
+    addExtraOpts(pkt6);
+
     pkt6->pack();
     IfaceMgr::instance().send(pkt6);
     if (!preload) {
@@ -2250,6 +2280,10 @@ TestControl::sendSolicit6(const TestControlSocket& socket,
     // Prepare on-wire data.
     pkt6->rawPack();
     setDefaults6(socket, pkt6);
+
+    // Add any extra options that user may have specified.
+    addExtraOpts(pkt6);
+
     // Send solicit packet.
     IfaceMgr::instance().send(pkt6);
     if (!preload) {
@@ -2321,6 +2355,26 @@ TestControl::setDefaults6(const TestControlSocket& socket,
       relay_info.linkaddr_ = IOAddress(socket.addr_);
       relay_info.peeraddr_ = IOAddress(socket.addr_);
       pkt->addRelayInfo(relay_info);
+    }
+}
+
+void
+TestControl::addExtraOpts(const Pkt4Ptr& pkt) {
+    // All all extra options that the user may have specified
+    CommandOptions& options = CommandOptions::instance();
+    const dhcp::OptionCollection& extra_opts = options.getExtraOpts();
+    for (auto entry : extra_opts) {
+        pkt->addOption(entry.second);
+    }
+}
+
+void
+TestControl::addExtraOpts(const Pkt6Ptr& pkt) {
+    // All all extra options that the user may have specified
+    CommandOptions& options = CommandOptions::instance();
+    const dhcp::OptionCollection& extra_opts = options.getExtraOpts();
+    for (auto entry : extra_opts) {
+        pkt->addOption(entry.second);
     }
 }
 

--- a/src/bin/perfdhcp/test_control.cc
+++ b/src/bin/perfdhcp/test_control.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/bin/perfdhcp/test_control.h
+++ b/src/bin/perfdhcp/test_control.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/bin/perfdhcp/test_control.h
+++ b/src/bin/perfdhcp/test_control.h
@@ -939,6 +939,26 @@ protected:
     void setDefaults6(const TestControlSocket& socket,
                       const dhcp::Pkt6Ptr& pkt);
 
+    /// @brief Inserts extra options specified by user.
+    ///
+    /// Note: addExtraOpts for v4 and v6 could easily be turned into a template.
+    /// However, this would require putting code here that uses CommandOptions,
+    /// and that would create dependency between test_control.h and
+    /// command_options.h.
+    ///
+    /// @param pkt4 options will be added here
+    void addExtraOpts(const dhcp::Pkt4Ptr& pkt4);
+
+    /// @brief Inserts extra options specified by user.
+    ///
+    /// Note: addExtraOpts for v4 and v6 could easily be turned into a template.
+    /// However, this would require putting code here that uses CommandOptions,
+    /// and that would create dependency between test_control.h and
+    /// command_options.h.
+    ///
+    /// @param pkt6 options will be added here
+    void addExtraOpts(const dhcp::Pkt6Ptr& pkt6);
+
     /// \brief Find if diagnostic flag has been set.
     ///
     /// \param diag diagnostic flag (a,e,i,s,r,t,T).

--- a/src/bin/perfdhcp/tests/command_options_unittest.cc
+++ b/src/bin/perfdhcp/tests/command_options_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/bin/perfdhcp/tests/test_control_unittest.cc
+++ b/src/bin/perfdhcp/tests/test_control_unittest.cc
@@ -12,6 +12,7 @@
 #include <asiolink/io_address.h>
 #include <exceptions/exceptions.h>
 #include <dhcp/dhcp4.h>
+#include <dhcp/pkt4.h>
 #include <dhcp/iface_mgr.h>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -91,8 +92,8 @@ public:
     void setRelativeDueTimes(const int send_secs, const int renew_secs = 0,
                              const int release_secs = 0) {
         ptime now = microsec_clock::universal_time();
-	// Use now to avoid unused but set warning
-	ASSERT_FALSE(now.is_special());
+        // Use now to avoid unused but set warning
+        ASSERT_FALSE(now.is_special());
         basic_rate_control_.setRelativeDue(send_secs);
         renew_rate_control_.setRelativeDue(renew_secs);
         release_rate_control_.setRelativeDue(release_secs);
@@ -121,6 +122,7 @@ public:
     using TestControl::registerOptionFactories;
     using TestControl::reset;
     using TestControl::sendDiscover4;
+    using TestControl::sendRequest4;
     using TestControl::sendPackets;
     using TestControl::sendMultipleRequests;
     using TestControl::sendMultipleMessages6;
@@ -136,6 +138,11 @@ public:
     using TestControl::macaddr_gen_;
     using TestControl::first_packet_serverid_;
     using TestControl::interrupted_;
+    using TestControl::testDiags;
+    using TestControl::template_packets_v4_;
+    using TestControl::template_packets_v6_;
+    using TestControl::ack_storage_;
+    using TestControl::sendRequestFromAck;
 
     NakedTestControl() : TestControl() {
         uint32_t clients_num = CommandOptions::instance().getClientsNum() == 0 ?
@@ -461,12 +468,13 @@ public:
     /// \param iterations_num number of exchanges to simulate.
     /// \param receive_num number of received OFFER packets.
     /// \param iterations_performed actual number of iterations.
+    /// \param tc test control instance
     void testPkt4Exchange(int iterations_num,
                           int receive_num,
                           bool use_templates,
-                          int& iterations_performed) const {
+                          int& iterations_performed,
+                          NakedTestControl& tc) const {
         int sock_handle = 0;
-        NakedTestControl tc;
         tc.initializeStatsMgr();
 
         // Use templates files to crate packets.
@@ -525,12 +533,13 @@ public:
     /// \param iterations_num number of exchanges to simulate.
     /// \param receive_num number of received OFFER packets.
     /// \param iterations_performed actual number of iterations.
+    /// \param tc test control instance
     void testPkt6Exchange(int iterations_num,
                           int receive_num,
                           bool use_templates,
-                          int& iterations_performed) const {
+                          int& iterations_performed,
+                          NakedTestControl& tc) const {
         int sock_handle = 0;
-        NakedTestControl tc;
         tc.initializeStatsMgr();
 
         // Use templates files to crate packets.
@@ -1062,6 +1071,38 @@ public:
 
     }
 
+    /// @brief check if v4 options 200 and 201 are present.
+    ///
+    /// The options are expected to have specific format, as if parameters
+    /// -o 200,abcdef1234, -o 201,00 were passed to the command line.
+    void checkOptions20x(const Pkt4Ptr& pkt) {
+        ASSERT_TRUE(pkt);
+        OptionPtr opt = pkt->getOption(200);
+        ASSERT_TRUE(opt);
+        EXPECT_TRUE(opt->getUniverse() == Option::V4);
+        EXPECT_EQ(opt->toText(), "type=200, len=005: ab:cd:ef:12:34");
+
+        opt = pkt->getOption(201);
+        ASSERT_TRUE(opt);
+        EXPECT_EQ(opt->toText(), "type=201, len=001: 00");
+    }
+
+    /// @brief check if v6 options 200 and 201 are present.
+    ///
+    /// The options are expected to have specific format, as if parameters
+    /// -o 200,abcdef1234, -o 201,00 were passed to the command line.
+    void checkOptions20x(const Pkt6Ptr& pkt) {
+        ASSERT_TRUE(pkt);
+        OptionPtr opt = pkt->getOption(200);
+        ASSERT_TRUE(opt);
+        EXPECT_TRUE(opt->getUniverse() == Option::V6);
+        EXPECT_EQ(opt->toText(), "type=00200, len=00005: ab:cd:ef:12:34");
+
+        opt = pkt->getOption(201);
+        ASSERT_TRUE(opt);
+        EXPECT_EQ(opt->toText(), "type=00201, len=00001: 00");
+    }
+
 };
 
 // This test verifies that the class members are reset to expected values.
@@ -1472,7 +1513,8 @@ TEST_F(TestControlTest, Packet4Exchange) {
     // following variable.
     int iterations_performed = 0;
     bool use_templates = false;
-    testPkt4Exchange(iterations_num, iterations_num, use_templates, iterations_performed);
+    NakedTestControl tc;
+    testPkt4Exchange(iterations_num, iterations_num, use_templates, iterations_performed, tc);
     // The command line restricts the number of iterations to 10
     // with -n 10 parameter.
     EXPECT_EQ(10, iterations_performed);
@@ -1492,7 +1534,7 @@ TEST_F(TestControlTest, Packet4Exchange) {
     // will be reached.
     const int received_num = 10;
     use_templates = true;
-    testPkt4Exchange(iterations_num, received_num, use_templates, iterations_performed);
+    testPkt4Exchange(iterations_num, received_num, use_templates, iterations_performed, tc);
     EXPECT_EQ(12, iterations_performed);
 }
 
@@ -1515,8 +1557,9 @@ TEST_F(TestControlTest, Packet6ExchangeFromTemplate) {
     // Set number of received packets equal to number of iterations.
     // This simulates no packet drops.
     bool use_templates = false;
+    NakedTestControl tc;
     testPkt6Exchange(iterations_num, iterations_num, use_templates,
-                     iterations_performed);
+                     iterations_performed, tc);
     // Actual number of iterations should be 10.
     EXPECT_EQ(10, iterations_performed);
 
@@ -1541,7 +1584,7 @@ TEST_F(TestControlTest, Packet6ExchangeFromTemplate) {
     // to simulate the IPv6 address acquisition and to verify that the
     // IA_NA options returned by the server are processed correctly.
     testPkt6Exchange(iterations_num, received_num, use_templates,
-                     iterations_performed);
+                     iterations_performed, tc);
     EXPECT_EQ(6, iterations_performed);
 }
 
@@ -1575,8 +1618,9 @@ TEST_F(TestControlTest, Packet6Exchange) {
     // parameter (10 in this case). All exchanged packets carry the IA_NA option
     // to simulate the IPv6 address acquisition and to verify that the IA_NA
     // options returned by the server are processed correctly.
+    NakedTestControl tc;
     testPkt6Exchange(iterations_num, iterations_num, use_templates,
-                     iterations_performed);
+                     iterations_performed, tc);
     // Actual number of iterations should be 10.
     EXPECT_EQ(10, iterations_performed);
 }
@@ -1611,8 +1655,9 @@ TEST_F(TestControlTest, Packet6ExchangePrefixDelegation) {
     // parameter (10 in this case). All exchanged packets carry the IA_PD option
     // to simulate the Prefix Delegation and to verify that the IA_PD options
     // returned by the server are processed correctly.
+    NakedTestControl tc;
     testPkt6Exchange(iterations_num, iterations_num, use_templates,
-                     iterations_performed);
+                     iterations_performed, tc);
     // Actual number of iterations should be 10.
     EXPECT_EQ(10, iterations_performed);
 }
@@ -1647,8 +1692,9 @@ TEST_F(TestControlTest, Packet6ExchangeAddressAndPrefix) {
     // or IA_PD options to simulate the address and prefix acquisition with
     // the single message and to verify that the IA_NA and IA_PD options
     // returned by the server are processed correctly.
+    NakedTestControl tc;
     testPkt6Exchange(iterations_num, iterations_num, use_templates,
-                     iterations_performed);
+                     iterations_performed, tc);
     // Actual number of iterations should be 10.
     EXPECT_EQ(10, iterations_performed);
 }
@@ -1888,5 +1934,128 @@ TEST_F(TestControlTest, getCurrentTimeoutRenewRelease) {
     tc.setRelativeDueTimes(5, 8, 9);
     EXPECT_GT(tc.getCurrentTimeout(), 0);
     EXPECT_LE(tc.getCurrentTimeout(), 5000000);
+
+}
+
+// Test checks if sendDiscover really includes custom options
+TEST_F(TestControlTest, sendDiscoverExtraOpts) {
+
+    // Important paramters here:
+    // -xT - save first packet of each type for templates (useful for packet inspection)
+    // -o 200,abcdef1234 - send option 200 with hex content: ab:cd:ef:12:34
+    // -o 201,00 - send option 201 with hex content: 00
+    std::string loopback(getLocalLoopback());
+    ASSERT_NO_THROW(processCmdLine("perfdhcp -4 -l " + loopback
+                    + " -xT -L 10068 -o 200,abcdef1234 -o 201,00 -r 1 127.0.0.1"));
+
+    // Create test control and set up some basic defaults.
+    NakedTestControl tc;
+    tc.initializeStatsMgr();
+    tc.registerOptionFactories();
+    NakedTestControl::IncrementalGeneratorPtr gen(new NakedTestControl::IncrementalGenerator());
+    tc.setTransidGenerator(gen);
+
+    // Socket is needed to send packets through the interface.
+    int sock_handle = 0;
+    ASSERT_NO_THROW(sock_handle = tc.openSocket());
+    TestControl::TestControlSocket sock(sock_handle);
+
+    // Make tc send the packet. The first packet of each type is saved in templates.
+    ASSERT_NO_THROW(tc.sendDiscover4(sock));
+
+    // Let's find the packet and see if it includes the right option.
+    auto pkt_it = tc.template_packets_v4_.find(DHCPDISCOVER);
+    ASSERT_TRUE(pkt_it != tc.template_packets_v4_.end());
+
+    checkOptions20x(pkt_it->second);
+}
+
+// Test checks if regular packet exchange inserts the extra v4 options
+// specified on command line.
+TEST_F(TestControlTest, Packet4ExchangeExtraOpts) {
+
+    // Get the local loopback interface to open socket on
+    // it and test packets exchanges. We don't want to fail
+    // the test if interface is not available.
+    std::string loopback(getLocalLoopback());
+    if (loopback.empty()) {
+        std::cout << "Unable to find the loopback interface. Skip test." << std::endl;
+        return;
+    }
+
+    // Important paramters here:
+    // -xT - save first packet of each type for templates (useful for packet inspection)
+    // -o 200,abcdef1234 - send option 200 with hex content: ab:cd:ef:12:34
+    // -o 201,00 - send option 201 with hex content: 00
+    const int iterations_num = 1;
+    processCmdLine("perfdhcp -l " + loopback + " -4 " +
+                   "-o 200,abcdef1234 -o 201,00 " +
+                   "-r 100 -n 10 -R 20 -xT -L 10547 127.0.0.1");
+
+    int iterations_performed = 0;
+    NakedTestControl tc;
+    tc.registerOptionFactories();
+
+    // Do the actual exchange.
+    testPkt4Exchange(iterations_num, iterations_num, false, iterations_performed, tc);
+    EXPECT_EQ(1, iterations_performed);
+
+    // Check if Discover was recored and if it contains options 200 and 201.
+    auto disc = tc.template_packets_v4_.find(DHCPDISCOVER);
+    ASSERT_TRUE(disc != tc.template_packets_v4_.end());
+    checkOptions20x(disc->second);
+
+    // Check if Request was recored and if it contains options 200 and 201.
+    auto req = tc.template_packets_v4_.find(DHCPREQUEST);
+    ASSERT_TRUE(req != tc.template_packets_v4_.end());
+    checkOptions20x(req->second);
+}
+
+// Test checks if regular packet exchange inserts the extra v6 options
+// specified on command line.
+TEST_F(TestControlTest, Packet6ExchangeExtraOpts) {
+    // Get the local loopback interface to open socket on
+    // it and test packets exchanges. We don't want to fail
+    // the test if interface is not available.
+    std::string loopback(getLocalLoopback());
+    if (loopback.empty()) {
+        std::cout << "Unable to find the loopback interface. Skip test."
+                  << std::endl;
+        return;
+    }
+
+    // Important paramters here:
+    // -xT - save first packet of each type for templates (useful for packet inspection)
+    // -o 200,abcdef1234 - send option 200 with hex content: ab:cd:ef:12:34
+    // -o 201,00 - send option 201 with hex content: 00
+    const int iterations_num = 1;
+    processCmdLine("perfdhcp -l " + loopback
+                   + " -6 -e address-only"
+                   + " -xT -o 200,abcdef1234 -o 201,00 "
+                   + " -r 100 -n 10 -R 20 -L 10547 ::1");
+    int iterations_performed = 0;
+    // Set number of received packets equal to number of iterations.
+    // This simulates no packet drops.
+    bool use_templates = false;
+
+    // Simulate the number of Solicit-Advertise-Request-Reply (SARR) exchanges.
+    // The test function generates server's responses and passes it to the
+    // TestControl class methods for processing. The number of exchanges
+    // actually performed is returned in 'iterations_performed' argument.
+    // First packet of each type is recorded as a template packet. The check
+    // inspects this template to see if the expected options are really there.
+    NakedTestControl tc;
+    testPkt6Exchange(iterations_num, iterations_num, false,
+                     iterations_performed, tc);
+
+    // Check if Solicit was recored and if it contains options 200 and 201.
+    auto sol = tc.template_packets_v6_.find(DHCPV6_SOLICIT);
+    ASSERT_TRUE(sol != tc.template_packets_v6_.end());
+    checkOptions20x(sol->second);
+
+    // Check if Request was recored and if it contains options 200 and 201.
+    auto req = tc.template_packets_v6_.find(DHCPV6_REQUEST);
+    ASSERT_TRUE(req != tc.template_packets_v6_.end());
+    checkOptions20x(req->second);
 
 }

--- a/src/bin/shell/kea-shell.xml
+++ b/src/bin/shell/kea-shell.xml
@@ -35,7 +35,7 @@
 
   <docinfo>
     <copyright>
-      <year>2017</year>
+      <year>2017-2018</year>
       <holder>Internet Systems Consortium, Inc. ("ISC")</holder>
     </copyright>
   </docinfo>

--- a/src/lib/asiolink/io_acceptor.h
+++ b/src/lib/asiolink/io_acceptor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2017-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/asiolink/io_asio_socket.h
+++ b/src/lib/asiolink/io_asio_socket.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2010-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/asiolink/io_service.h
+++ b/src/lib/asiolink/io_service.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2011-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/asiolink/tests/io_service_unittest.cc
+++ b/src/lib/asiolink/tests/io_service_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2015 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2013-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/asiolink/tests/run_unittests.cc
+++ b/src/lib/asiolink/tests/run_unittests.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2015 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2009-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/asiolink/udp_socket.h
+++ b/src/lib/asiolink/udp_socket.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2015 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2011-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/cc/tests/json_feed_unittests.cc
+++ b/src/lib/cc/tests/json_feed_unittests.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2017-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcp/dhcp6.h
+++ b/src/lib/dhcp/dhcp6.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2006-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2006-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcp/option_custom.cc
+++ b/src/lib/dhcp/option_custom.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcp/std_option_defs.h
+++ b/src/lib/dhcp/std_option_defs.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcp/tests/libdhcp++_unittest.cc
+++ b/src/lib/dhcp/tests/libdhcp++_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2011-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/cfg_hosts.cc
+++ b/src/lib/dhcpsrv/cfg_hosts.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2014-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/cfg_hosts.h
+++ b/src/lib/dhcpsrv/cfg_hosts.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2014-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/cfg_option.cc
+++ b/src/lib/dhcpsrv/cfg_option.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2014-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/cfg_option.h
+++ b/src/lib/dhcpsrv/cfg_option.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2014-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/mysql_host_data_source.cc
+++ b/src/lib/dhcpsrv/mysql_host_data_source.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2015-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2015-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/mysql_host_data_source.h
+++ b/src/lib/dhcpsrv/mysql_host_data_source.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2015-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/network_state.cc
+++ b/src/lib/dhcpsrv/network_state.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2017-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/tests/callout_handle_store_unittest.cc
+++ b/src/lib/dhcpsrv/tests/callout_handle_store_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/tests/cfg_shared_networks4_unittest.cc
+++ b/src/lib/dhcpsrv/tests/cfg_shared_networks4_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2017-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/tests/cfg_shared_networks6_unittest.cc
+++ b/src/lib/dhcpsrv/tests/cfg_shared_networks6_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2017-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/tests/csv_lease_file4_unittest.cc
+++ b/src/lib/dhcpsrv/tests/csv_lease_file4_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2016 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2014-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/tests/csv_lease_file6_unittest.cc
+++ b/src/lib/dhcpsrv/tests/csv_lease_file6_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2016 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2014-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/tests/dhcp_parsers_unittest.cc
+++ b/src/lib/dhcpsrv/tests/dhcp_parsers_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/tests/lease_file_loader_unittest.cc
+++ b/src/lib/dhcpsrv/tests/lease_file_loader_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2015-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2015-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/testutils/lease_file_io.cc
+++ b/src/lib/dhcpsrv/testutils/lease_file_io.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2015 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2015-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/dhcpsrv/testutils/lease_file_io.h
+++ b/src/lib/dhcpsrv/testutils/lease_file_io.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2014-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/eval/lexer.cc
+++ b/src/lib/eval/lexer.cc
@@ -1010,7 +1010,7 @@ goto find_rule; \
 #define YY_RESTORE_YY_MORE_OFFSET
 char *yytext;
 #line 1 "lexer.ll"
-/* Copyright (C) 2015-2017 Internet Systems Consortium, Inc. ("ISC")
+/* Copyright (C) 2015-2018 Internet Systems Consortium, Inc. ("ISC")
 
    This Source Code Form is subject to the terms of the Mozilla Public
    License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/hooks/callout_handle.cc
+++ b/src/lib/hooks/callout_handle.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2015 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2013-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/hooks/hooks_manager.cc
+++ b/src/lib/hooks/hooks_manager.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2013-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/hooks/server_hooks.cc
+++ b/src/lib/hooks/server_hooks.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2013-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/hooks/tests/test_libraries.h.in
+++ b/src/lib/hooks/tests/test_libraries.h.in
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2016 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2013-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/http/tests/response_parser_unittests.cc
+++ b/src/lib/http/tests/response_parser_unittests.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2017-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/stats/tests/observation_unittest.cc
+++ b/src/lib/stats/tests/observation_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2015-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2015-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/lib/util/threads/tests/condvar_unittest.cc
+++ b/src/lib/util/threads/tests/condvar_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2012-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/share/database/scripts/mysql/dhcpdb_drop.mysql
+++ b/src/share/database/scripts/mysql/dhcpdb_drop.mysql
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 Internet Systems Consortium.
+# Copyright (C) 2016-2018 Internet Systems Consortium, Inc. ("ISC")
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/system_messages.cc
+++ b/tools/system_messages.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2015-2017 Internet Systems Consortium, Inc. ("ISC")
+// Copyright (C) 2015-2018 Internet Systems Consortium, Inc. ("ISC")
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
The code addressing issue #77 is ready for review. Here's what I did:

1. created the issue #77.
2. created branch github77 and committed the code improvements there.
3. pushed that branch to github
4. opened this pull request (if you push something to branch, there's a new button on the front page (https://github.com/isc-projects/kea/) that says "you recently pushed branches ABCD and there's compare & open PR button next to it).

So here it is. Please review and post your comments here on github. Feel free to experiment with the github features. The code change itself is rather benign.