### PR TITLE
Add unfiltered getAll to CfgHosts

### DIFF
--- a/src/lib/dhcpsrv/cfg_hosts.cc
+++ b/src/lib/dhcpsrv/cfg_hosts.cc
@@ -24,6 +24,28 @@ namespace isc {
 namespace dhcp {
 
 ConstHostCollection
+CfgHosts::getAll() const {
+    ConstHostCollection collection;
+    const HostContainerIndex0& idx = hosts_.get<0>();
+    for (HostContainerIndex0::const_iterator host = idx.begin();
+         host != idx.end(); ++host) {
+        collection.push_back(*host);
+    }
+    return (collection);
+}
+
+HostCollection
+CfgHosts::getAll() {
+    HostCollection collection;
+    const HostContainerIndex0& idx = hosts_.get<0>();
+    for (HostContainerIndex0::const_iterator host = idx.begin();
+         host != idx.end(); ++host) {
+        collection.push_back(*host);
+    }
+    return (collection);
+}
+
+ConstHostCollection
 CfgHosts::getAll(const Host::IdentifierType& identifier_type,
                  const uint8_t* identifier_begin,
                  const size_t identifier_len) const {

--- a/src/lib/dhcpsrv/cfg_hosts.h
+++ b/src/lib/dhcpsrv/cfg_hosts.h
@@ -41,6 +41,24 @@ public:
     /// @brief Destructor.
     virtual ~CfgHosts() { }
 
+    /// @brief Return all hosts
+    ///
+    /// This method returns all @c Host objects which represent reservations
+    /// in this configuration.
+    ///
+    /// @return Collection of const @c Host objects.
+    virtual ConstHostCollection
+    getAll() const;
+
+    /// @brief Non-const version of the @c getAll const method.
+    ///
+    /// This method returns all @c Host objects which represent reservations
+    /// in this configuration.
+    ///
+    /// @return Collection of non-const @c Host objects.
+    virtual HostCollection
+    getAll();
+
     /// @brief Return all hosts connected to any subnet for which reservations
     /// have been made using a specified identifier.
     ///


### PR DESCRIPTION
Add getAll() without parameters to class CfgHosts.
Useful for, e.g., "dhcp4_srv_configured" hooks that want to iterator
over all host reservations.