### PR TITLE
added .NOTPARALLEL to parser generated file targets

### DIFF
--- a/src/bin/agent/Makefile.am
+++ b/src/bin/agent/Makefile.am
@@ -110,6 +110,8 @@ parser: agent_lexer.cc location.hh position.hh stack.hh agent_parser.cc agent_pa
 location.hh position.hh stack.hh agent_parser.cc agent_parser.h: agent_parser.yy
 	$(YACC) --defines=agent_parser.h --report=all --report-file=agent_parser.report -o agent_parser.cc agent_parser.yy
 
+.NOTPARALLEL: location.hh position.hh stack.hh agent_parser.cc agent_parser.h
+
 agent_lexer.cc: agent_lexer.ll
 	$(LEX) --prefix agent_ -o agent_lexer.cc agent_lexer.ll
 

--- a/src/bin/d2/Makefile.am
+++ b/src/bin/d2/Makefile.am
@@ -149,6 +149,8 @@ parser: d2_lexer.cc location.hh position.hh stack.hh d2_parser.cc d2_parser.h
 location.hh position.hh stack.hh d2_parser.cc d2_parser.h: d2_parser.yy
 	$(YACC) --defines=d2_parser.h --report=all --report-file=d2_parser.report -o d2_parser.cc d2_parser.yy
 
+.NOTPARALLEL: location.hh position.hh stack.hh d2_parser.cc d2_parser.h
+
 d2_lexer.cc: d2_lexer.ll
 	$(LEX) --prefix d2_parser_ -o d2_lexer.cc d2_lexer.ll
 

--- a/src/bin/dhcp4/Makefile.am
+++ b/src/bin/dhcp4/Makefile.am
@@ -132,6 +132,8 @@ parser: dhcp4_lexer.cc location.hh position.hh stack.hh dhcp4_parser.cc dhcp4_pa
 location.hh position.hh stack.hh dhcp4_parser.cc dhcp4_parser.h: dhcp4_parser.yy
 	$(YACC) --defines=dhcp4_parser.h --report=all --report-file=dhcp4_parser.report -o dhcp4_parser.cc dhcp4_parser.yy
 
+.NOTPARALLEL: location.hh position.hh stack.hh dhcp4_parser.cc dhcp4_parser.h
+
 dhcp4_lexer.cc: dhcp4_lexer.ll
 	$(LEX) --prefix parser4_ -o dhcp4_lexer.cc dhcp4_lexer.ll
 

--- a/src/bin/dhcp6/Makefile.am
+++ b/src/bin/dhcp6/Makefile.am
@@ -133,6 +133,8 @@ parser: dhcp6_lexer.cc location.hh position.hh stack.hh dhcp6_parser.cc dhcp6_pa
 location.hh position.hh stack.hh dhcp6_parser.cc dhcp6_parser.h: dhcp6_parser.yy
 	$(YACC) --defines=dhcp6_parser.h --report=all --report-file=dhcp6_parser.report -o dhcp6_parser.cc dhcp6_parser.yy
 
+.NOTPARALLEL: location.hh position.hh stack.hh dhcp6_parser.cc dhcp6_parser.h
+
 dhcp6_lexer.cc: dhcp6_lexer.ll
 	$(LEX) --prefix parser6_ -o dhcp6_lexer.cc dhcp6_lexer.ll
 

--- a/src/lib/eval/Makefile.am
+++ b/src/lib/eval/Makefile.am
@@ -94,6 +94,8 @@ parser: lexer.cc location.hh position.hh stack.hh parser.cc parser.h
 location.hh position.hh stack.hh parser.cc parser.h: parser.yy
 	$(YACC) --defines=parser.h -o parser.cc parser.yy
 
+.NOTPARALLEL: location.hh position.hh stack.hh parser.cc parser.h
+
 lexer.cc: lexer.ll
 	$(LEX) --prefix eval -o lexer.cc lexer.ll
 


### PR DESCRIPTION
Thank you for your time reading this! Small change, but straightforward. I was having problems with the make process being halted midway because of this even though it generated the right parser files.

Issue scenario:

`make -j 2`

> [...]
> bison -y --defines=agent_parser.h --report=all --report-file=agent_parser.report -o agent_parser.cc agent_parser.yy
> bison -y --defines=agent_parser.h --report=all --report-file=agent_parser.report -o agent_parser.cc agent_parser.yy
> [...]

One `yacc` command is sufficient to generate all the required files. Adding `.NOTPARALLEL` to the Makefile.am removes the duplicate commands by processing each target sequentially. For a clean build, with the `location.hh position.hh stack.hh agent_parser.cc agent_parser.h` targets, `location.hh` target is trigerred first and runs the `yacc` comamnd. When `position.hh` is triggered next, itself would have been generated by the previous `yacc` command.