### PR TITLE
proposed fix for https://kea.isc.org/ticket/5048

### DIFF
--- a/src/bin/dhcp6/dhcp6_srv.cc
+++ b/src/bin/dhcp6/dhcp6_srv.cc
@@ -1540,17 +1540,18 @@ Dhcpv6Srv::processClientFqdn(const Pkt6Ptr& question, const Pkt6Ptr& answer,
     // current configuration.
     d2_mgr.adjustFqdnFlags<Option6ClientFqdn>(*fqdn, *fqdn_resp);
 
+    std::string domain_suffix = ctx.get_domain_suffix();
     // If there's a reservation and it has a hostname specified, use it!
     if (ctx.currentHost() && !ctx.currentHost()->getHostname().empty()) {
         // Add the qualifying suffix.
         // After #3765, this will only occur if the suffix is not empty.
-        fqdn_resp->setDomainName(d2_mgr.qualifyName(ctx.currentHost()->getHostname(),
+        fqdn_resp->setDomainName(d2_mgr.qualifyName(ctx.currentHost()->getHostname(), domain_suffix,
                                                     true),
                                                     Option6ClientFqdn::FULL);
     } else {
         // Adjust the domain name based on domain name value and type sent by
         // the client and current configuration.
-        d2_mgr.adjustDomainName<Option6ClientFqdn>(*fqdn, *fqdn_resp);
+        d2_mgr.adjustDomainName<Option6ClientFqdn>(*fqdn, *fqdn_resp, domain_suffix);
     }
 
     // Once we have the FQDN setup to use it for the lease hostname.  This
@@ -3521,7 +3522,7 @@ Dhcpv6Srv::updateReservedFqdn(const AllocEngine::ClientContext6& ctx,
    if (ctx.currentHost() &&
        !ctx.currentHost()->getHostname().empty()) {
        std::string new_name = CfgMgr::instance().getD2ClientMgr().
-           qualifyName(ctx.currentHost()->getHostname(), true);
+           qualifyName(ctx.currentHost()->getHostname(), ctx.get_domain_suffix(), true);
 
        if (new_name != name) {
            fqdn->setDomainName(new_name, Option6ClientFqdn::FULL);

--- a/src/lib/dhcpsrv/alloc_engine.h
+++ b/src/lib/dhcpsrv/alloc_engine.h
@@ -315,6 +315,8 @@ public:
     /// new information doesn't modify the API of the allocation engine.
     struct ClientContext6 : public boost::noncopyable {
 
+        std::string get_domain_suffix()const;
+
         /// @name Parameters pertaining to DHCPv6 message
         //@{
 
@@ -1072,6 +1074,9 @@ public:
     /// information to the allocation engine methods is that adding
     /// new information doesn't modify the API of the allocation engine.
     struct ClientContext4 : public boost::noncopyable {
+
+        std::string get_domain_suffix()const;
+
         /// @brief Subnet selected for the client by the server.
         Subnet4Ptr subnet_;
 

--- a/src/lib/dhcpsrv/d2_client_mgr.cc
+++ b/src/lib/dhcpsrv/d2_client_mgr.cc
@@ -173,24 +173,29 @@ D2ClientMgr::generateFqdn(const asiolink::IOAddress& address,
 
     std::ostringstream gen_name;
     gen_name << d2_client_config_->getGeneratedPrefix() << "-" << hostname;
-    return (qualifyName(gen_name.str(), trailing_dot));
+    return (qualifyName(gen_name.str(), "", trailing_dot));
 }
 
 
 std::string
-D2ClientMgr::qualifyName(const std::string& partial_name,
+D2ClientMgr::qualifyName(const std::string& partial_name, const std::string& domain_suffix,
                          const bool trailing_dot) const {
     std::ostringstream gen_name;
 
     gen_name << partial_name;
-    if (!d2_client_config_->getQualifyingSuffix().empty()) {
+
+    std::string suffix = domain_suffix;
+    if(suffix.empty())
+        suffix = d2_client_config_->getQualifyingSuffix();
+
+    if (!suffix.empty()) {
         std::string str = gen_name.str();
         size_t len = str.length();
         if ((len > 0) && (str[len - 1] != '.')) {
             gen_name << ".";
         }
 
-        gen_name << d2_client_config_->getQualifyingSuffix();
+        gen_name << suffix;
     }
 
     std::string str = gen_name.str();

--- a/src/lib/dhcpsrv/d2_client_mgr.h
+++ b/src/lib/dhcpsrv/d2_client_mgr.h
@@ -185,7 +185,7 @@ public:
     /// suffix itself is empty (i.e. "").
     ///
     /// @return std::string containing the qualified name.
-    std::string qualifyName(const std::string& partial_name,
+    std::string qualifyName(const std::string& partial_name, const std::string& domain_suffix,
                             const bool trailing_dot) const;
 
     /// @brief Set server FQDN flags based on configuration and a given FQDN
@@ -243,7 +243,7 @@ public:
     /// @tparam T  FQDN Option class containing the FQDN data such as
     /// dhcp::Option4ClientFqdn or dhcp::Option6ClientFqdn
     template <class T>
-    void adjustDomainName(const T& fqdn, T& fqdn_resp);
+    void adjustDomainName(const T& fqdn, T& fqdn_resp, const std::string& domain_suffix);
 
     /// @brief Enables sending NameChangeRequests to kea-dhcp-ddns
     ///
@@ -454,7 +454,7 @@ D2ClientMgr::getUpdateDirections(const T& fqdn_resp,
 
 template <class T>
 void
-D2ClientMgr::adjustDomainName(const T& fqdn, T& fqdn_resp) {
+D2ClientMgr::adjustDomainName(const T& fqdn, T& fqdn_resp, const std::string & domain_suffix) {
     // If we're configured to replace it or the supplied name is blank
     // set the response name to blank.
     if ((d2_client_config_->getReplaceClientNameMode() == D2ClientConfig::RCM_ALWAYS ||
@@ -464,7 +464,7 @@ D2ClientMgr::adjustDomainName(const T& fqdn, T& fqdn_resp) {
     } else {
         // If the supplied name is partial, qualify it by adding the suffix.
         if (fqdn.getDomainNameType() == T::PARTIAL) {
-            fqdn_resp.setDomainName(qualifyName(fqdn.getDomainName(),true), T::FULL);
+            fqdn_resp.setDomainName(qualifyName(fqdn.getDomainName(), domain_suffix, true), T::FULL);
         }
     }
 }


### PR DESCRIPTION
Proposed fix for:
https://oldkea.isc.org/ticket/5048
"Kea servers should be able to use a subnet's domain-name as a qualifying suffix for DDNS"

https://lists.isc.org/pipermail/kea-users/2017-January/000776.html
https://lists.isc.org/pipermail/kea-users/2017-February/000813.html