### PR TITLE
Update dhcp6-srv.xml

### DIFF
--- a/doc/guide/dhcp6-srv.xml
+++ b/doc/guide/dhcp6-srv.xml
@@ -1630,7 +1630,7 @@ temporarily override a list of interface names and listen on all interfaces.
     "data": "2, 3/4",
 }
 </screen>
-              Another possible "space" value is "s46-v4v6bind", to include
+              Another possible "space" value is "s46-v4v6bind-options", to include
               this option in the S46 IPv4/IPv6 Address Binding option.
             </para>
             <para>


### PR DESCRIPTION
Name of "space" value for s46-portparams fixed to "s46-v4v6bind-options"