### PR TITLE
[📦 NEW] high level Translator abstractizations

### DIFF
--- a/src/lib/yang/testutils/translator_test.cc
+++ b/src/lib/yang/testutils/translator_test.cc
@@ -95,7 +95,7 @@ YangRepr::YangReprItem::get(const string& xpath, S_Session session) {
 
         default:
             isc_throw(NotImplemented,
-                      "YangReprItem called with unupported type: " << type);
+                      "YangReprItem called with unsupported type: " << type);
         }
     } catch (const sysrepo_exception& ex) {
         isc_throw(SysrepoError,
@@ -270,7 +270,7 @@ YangRepr::set(const Tree& tree, S_Session session) const {
 
             default:
                 isc_throw(NotImplemented,
-                          "YangRepr::set called with unupported type: "
+                          "YangRepr::set called with unsupported type: "
                           << item.type_);
             }
             session->set_item(item.xpath_.c_str(), s_val);


### PR DESCRIPTION
Here's some methods I use that get rid of repetitive code in `src/lib/yang`:


Before:
```
    ConstElementPtr user = elem->get("user");
    if (user) {
        setItem(xpath + "/user", user, SR_STRING_T);
    }
```
After:
```
   checkAndSetLeaf(elem, xpath, "user", SR_STRING_T);
```


Before:
```
    for (size_t i = 0; i < elem->size(); ++i) {
        ConstElementPtr database = elem->get(i);
        if (!database->contains("type")) {
            isc_throw(BadValue, "database without type: " << database->str());
        }
        string type = database->get("type")->stringValue();
        ostringstream key;
        key << xpath << "[database-type='" << type << "']";
        setDatabase(key.str(), database, true);
    }
```

After:
```
   checkAndSetList(elem, xpath, "lease-database", "database-type", *this, &TranslatorDatabase::setDatabase);
```

And so on
