### PR TITLE
cryptolink: Fix build with libressl-3.5.2

### DIFF
--- a/src/lib/cryptolink/openssl_compat.h
+++ b/src/lib/cryptolink/openssl_compat.h
@@ -6,7 +6,7 @@
 
 #include <openssl/opensslv.h>
 
-#if defined(LIBRESSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER < 0x10100000L)
+#if (LIBRESSL_VERSION_NUMBER < 0x3050200fL) || (OPENSSL_VERSION_NUMBER < 0x10100000L)
 
 // This file is included by hash and hmac codes so KEA_H* macros
 // avoid to define unused inlines.


### PR DESCRIPTION
This fixes the build with `libressl-3.5.2` by enabling newer openssl APIs for version `3.5.2` and newer.