### PR TITLE
Fixed boolean in config example

### DIFF
--- a/src/bin/keactrl/kea-dhcp4.conf.pre
+++ b/src/bin/keactrl/kea-dhcp4.conf.pre
@@ -139,7 +139,7 @@
         // {
         //     "name": "domain-name-servers",
         //     "code": 6,
-        //     "csv-format": "true",
+        //     "csv-format": true,
         //     "space": "dhcp4",
         //     "data": "192.0.2.1, 192.0.2.2"
         // }

--- a/src/bin/keactrl/kea-dhcp6.conf.pre
+++ b/src/bin/keactrl/kea-dhcp6.conf.pre
@@ -127,7 +127,7 @@
         // {
         //     "name": "dns-servers",
         //     "code": 23,
-        //     "csv-format": "true",
+        //     "csv-format": true,
         //     "space": "dhcp6",
         //     "data": "2001:db8:2::45, 2001:db8:2::100"
         // }


### PR DESCRIPTION
Kea config example contains invalid definition of boolean:

```
# kea-dhcp6 -t /etc/kea/kea-dhcp6.conf
Syntax check failed with: /etc/kea/kea-dhcp6.conf:169.27-32: syntax error, unexpected constant string, expecting boolean
# kea-dhcp4 -t kea-dhcp4.conf 
Syntax check failed with: kea-dhcp4.conf:142.27-32: syntax error, unexpected constant string, expecting boolean
```