### PR TITLE
Add monitoring instrumentation around `dhcp-disable` state.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2201.	[func]		dhankins
+	New metrics pkt4-dhcp-disabled, pkt4-raw-received, disabled-by-db,
+	disabled-by-ha-local, disabled-by-ha-remote, disabled-by-user, and
+	disabled-globally provide monitoring level visibility into the network_state
+	manager, and closes a monitoring gap where packets dropped while disabled
+	are not counted by any metric.
+	While disabled, a WARN log is emitted every DISABLE_WARN_PACKET{4|6}(100)
+	dropped packets, in addition to the existing DEBUG log.
+
 2200.	[func]		piotrek
 	Kea now supports new DHCPv4 option code 121, Classless Static
 	Route option defined in RFC 3442.

--- a/src/bin/dhcp4/dhcp4_srv.cc
+++ b/src/bin/dhcp4/dhcp4_srv.cc
@@ -122,6 +122,8 @@ struct Dhcp4Hooks {
 /// List of statistics which is initialized to 0 during the DHCPv4
 /// server startup.
 std::set<std::string> dhcp4_statistics = {
+    "pkt4-dhcp-disabled",
+    "pkt4-raw-received",
     "pkt4-received",
     "pkt4-discover-received",
     "pkt4-offer-received",
@@ -1096,10 +1098,24 @@ Dhcpv4Srv::runOne() {
         return;
     }
 
+    isc::stats::StatsMgr& stats_mgr = isc::stats::StatsMgr::instance();
+
+    // Count raw packets received as soon as we know a packet has been read.
+    stats_mgr.addValue("pkt4-raw-received", static_cast<int64_t>(1));
+
     // If the DHCP service has been globally disabled, drop the packet.
     if (!network_state_->isServiceEnabled()) {
         LOG_DEBUG(bad_packet4_logger, DBGLVL_PKT_HANDLING, DHCP4_PACKET_DROP_0008)
             .arg(query->getLabel());
+
+        // Log a warning every DISABLE_WARN_PACKET4.
+        if (stats_mgr.getInteger("pkt4-dhcp-disabled") % DISABLE_WARN_PACKET4 == 0) {
+            LOG_WARN(dhcp4_logger, DHCP4_PACKET_DROP_0008)
+                .arg(query->getLabel());
+        }
+
+        // Count packets dropped due to (hopefully temporary) service disabled.
+        stats_mgr.addValue("pkt4-dhcp-disabled", static_cast<int64_t>(1));
         return;
     } else {
         if (MultiThreadingMgr::instance().getMode()) {

--- a/src/bin/dhcp4/dhcp4_srv.h
+++ b/src/bin/dhcp4/dhcp4_srv.h
@@ -40,6 +40,8 @@
 namespace isc {
 namespace dhcp {
 
+static const int64_t DISABLE_WARN_PACKET4 = 100;
+
 /// @brief DHCPv4 message exchange.
 ///
 /// This class represents the DHCPv4 message exchange. The message exchange

--- a/src/bin/dhcp4/tests/ctrl_dhcp4_srv_unittest.cc
+++ b/src/bin/dhcp4/tests/ctrl_dhcp4_srv_unittest.cc
@@ -634,11 +634,23 @@ TEST_F(CtrlChannelDhcpv4SrvTest, controlChannelStats) {
                     "  \"name\":\"bogus\" }}", response);
     EXPECT_EQ("{ \"arguments\": {  }, \"result\": 0 }", response);
 
+    // Set max sample count to 1 to match test expectation (disabled state
+    // gauges normally have 2 samples).
+    sendUnixCommand("{ \"command\" : \"statistic-sample-count-set-all\", "
+                    "  \"arguments\": { \"max-samples\": 1 }}", response);
+    EXPECT_EQ("{ \"result\": 0, \"text\": \"All statistics count limit are set.\" }", response);
     // Check statistic-get-all
     sendUnixCommand("{ \"command\" : \"statistic-get-all\", "
                     "  \"arguments\": {}}", response);
 
     std::set<std::string> initial_stats = {
+        "disabled-by-db",
+        "disabled-by-ha-local",
+        "disabled-by-ha-remote",
+        "disabled-by-user",
+        "disabled-globally",
+        "pkt4-dhcp-disabled",
+        "pkt4-raw-received",
         "pkt4-received",
         "pkt4-discover-received",
         "pkt4-offer-received",

--- a/src/bin/dhcp4/tests/dhcp4_test_utils.cc
+++ b/src/bin/dhcp4/tests/dhcp4_test_utils.cc
@@ -994,14 +994,17 @@ Dhcpv4SrvTest::pretendReceivingPkt(NakedDhcpv4Srv& srv, const std::string& confi
 
     using namespace isc::stats;
     StatsMgr& mgr = StatsMgr::instance();
+    ObservationPtr pkt4_raw_received = mgr.getObservation("pkt4-raw-received");
     ObservationPtr pkt4_rcvd = mgr.getObservation("pkt4-received");
     ObservationPtr tested_stat = mgr.getObservation(stat_name);
 
     // All expected statistics must be present.
+    ASSERT_TRUE(pkt4_raw_received);
     ASSERT_TRUE(pkt4_rcvd);
     ASSERT_TRUE(tested_stat);
 
     // They also must have expected values.
+    EXPECT_EQ(1, pkt4_raw_received->getInteger().first);
     EXPECT_EQ(1, pkt4_rcvd->getInteger().first);
     EXPECT_EQ(1, tested_stat->getInteger().first);
 }

--- a/src/bin/dhcp4/tests/dora_unittest.cc
+++ b/src/bin/dhcp4/tests/dora_unittest.cc
@@ -2504,6 +2504,8 @@ DORATest::statisticsDORA() {
     // Ok, let's check the statistics.
     using namespace isc::stats;
     StatsMgr& mgr = StatsMgr::instance();
+    ObservationPtr pkt4_dhcp_disabled = mgr.getObservatoin("pkt4-dhcp-disabled");
+    ObservationPtr pkt4_raw_received = mgr.getObservation("pkt4-raw-received");
     ObservationPtr pkt4_received = mgr.getObservation("pkt4-received");
     ObservationPtr pkt4_discover_received = mgr.getObservation("pkt4-discover-received");
     ObservationPtr pkt4_offer_sent = mgr.getObservation("pkt4-offer-sent");
@@ -2512,6 +2514,8 @@ DORATest::statisticsDORA() {
     ObservationPtr pkt4_sent = mgr.getObservation("pkt4-sent");
 
     // All expected statistics must be present.
+    ASSERT_TRUE(pkt4_dhcp_disabled);
+    ASSERT_TRUE(pkt4_raw_received);
     ASSERT_TRUE(pkt4_received);
     ASSERT_TRUE(pkt4_discover_received);
     ASSERT_TRUE(pkt4_offer_sent);
@@ -2520,6 +2524,8 @@ DORATest::statisticsDORA() {
     ASSERT_TRUE(pkt4_sent);
 
     // They also must have expected values.
+    EXPECT_EQ(0, pkt4_dhcp_disabled->getInteger().first);
+    EXPECT_EQ(2, pkt4_raw_received->getInteger().first);
     EXPECT_EQ(2, pkt4_received->getInteger().first);
     EXPECT_EQ(1, pkt4_discover_received->getInteger().first);
     EXPECT_EQ(1, pkt4_offer_sent->getInteger().first);
@@ -2535,6 +2541,8 @@ DORATest::statisticsDORA() {
     ASSERT_NO_THROW(client.doRequest());
 
     // Let's see if the stats are properly updated.
+    EXPECT_EQ(0, pkt4_dhcp_disabled->getInteger().first);
+    EXPECT_EQ(5, pkt4_raw_received->getInteger().first);
     EXPECT_EQ(5, pkt4_received->getInteger().first);
     EXPECT_EQ(1, pkt4_discover_received->getInteger().first);
     EXPECT_EQ(1, pkt4_offer_sent->getInteger().first);
@@ -2576,6 +2584,7 @@ DORATest::statisticsNAK() {
 
     using namespace isc::stats;
     StatsMgr& mgr = StatsMgr::instance();
+    ObservationPtr pkt4_raw_received = mgr.getObservation("pkt4-raw-received");
     ObservationPtr pkt4_received = mgr.getObservation("pkt4-received");
     ObservationPtr pkt4_request_received = mgr.getObservation("pkt4-request-received");
     ObservationPtr pkt4_ack_sent = mgr.getObservation("pkt4-ack-sent");
@@ -2583,6 +2592,7 @@ DORATest::statisticsNAK() {
     ObservationPtr pkt4_sent = mgr.getObservation("pkt4-sent");
 
     // All expected statistics must be present.
+    ASSERT_TRUE(pkt4_raw_received);
     ASSERT_TRUE(pkt4_received);
     ASSERT_TRUE(pkt4_request_received);
     ASSERT_FALSE(pkt4_ack_sent); // No acks were sent, no such statistic expected.
@@ -2590,6 +2600,7 @@ DORATest::statisticsNAK() {
     ASSERT_TRUE(pkt4_sent);
 
     // They also must have expected values.
+    EXPECT_EQ(1, pkt4_raw_received->getInteger().first);
     EXPECT_EQ(1, pkt4_received->getInteger().first);
     EXPECT_EQ(1, pkt4_request_received->getInteger().first);
     EXPECT_EQ(1, pkt4_nak_sent->getInteger().first);

--- a/src/bin/dhcp4/tests/inform_unittest.cc
+++ b/src/bin/dhcp4/tests/inform_unittest.cc
@@ -623,18 +623,21 @@ TEST_F(InformTest, statisticsInform) {
     // Ok, let's check the statistics.
     using namespace isc::stats;
     StatsMgr& mgr = StatsMgr::instance();
+    ObservationPtr pkt4_raw_received = mgr.getObservation("pkt4-raw-received");
     ObservationPtr pkt4_received = mgr.getObservation("pkt4-received");
     ObservationPtr pkt4_inform_received = mgr.getObservation("pkt4-inform-received");
     ObservationPtr pkt4_ack_sent = mgr.getObservation("pkt4-ack-sent");
     ObservationPtr pkt4_sent = mgr.getObservation("pkt4-sent");
 
     // All expected statistics must be present.
+    ASSERT_TRUE(pkt4_raw_received);
     ASSERT_TRUE(pkt4_received);
     ASSERT_TRUE(pkt4_inform_received);
     ASSERT_TRUE(pkt4_ack_sent);
     ASSERT_TRUE(pkt4_sent);
 
     // And they must have expected values.
+    EXPECT_EQ(1, pkt4_raw_received->getInteger().first);
     EXPECT_EQ(1, pkt4_received->getInteger().first);
     EXPECT_EQ(1, pkt4_inform_received->getInteger().first);
     EXPECT_EQ(1, pkt4_ack_sent->getInteger().first);
@@ -648,6 +651,7 @@ TEST_F(InformTest, statisticsInform) {
     ASSERT_NO_THROW(client.doInform());
 
     // Let's see if the stats are properly updated.
+    EXPECT_EQ(5, pkt4_raw_received->getInteger().first);
     EXPECT_EQ(5, pkt4_received->getInteger().first);
     EXPECT_EQ(5, pkt4_inform_received->getInteger().first);
     EXPECT_EQ(5, pkt4_ack_sent->getInteger().first);

--- a/src/bin/dhcp6/dhcp6_srv.cc
+++ b/src/bin/dhcp6/dhcp6_srv.cc
@@ -178,6 +178,8 @@ createStatusCode(const Pkt6& pkt, const Option6IA& ia, const uint16_t status_cod
 /// List of statistics which is initialized to 0 during the DHCPv6
 /// server startup.
 std::set<std::string> dhcp6_statistics = {
+    "pkt6-dhcp-disabled",
+    "pkt6-raw-received",
     "pkt6-received",
     "pkt6-solicit-received",
     "pkt6-advertise-received",
@@ -684,10 +686,24 @@ Dhcpv6Srv::runOne() {
         return;
     }
 
+    isc::stats::StatsMgr& stats_mgr = isc::stats::StatsMgr::instance();
+
+    // Count raw packets received as soon as we know a packet has been read.
+    stats_mgr.addValue("pkt6-raw-received", static_cast<int64_t>(1));
+
     // If the DHCP service has been globally disabled, drop the packet.
     if (!network_state_->isServiceEnabled()) {
         LOG_DEBUG(bad_packet6_logger, DBGLVL_PKT_HANDLING, DHCP6_PACKET_DROP_DHCP_DISABLED)
             .arg(query->getLabel());
+
+        // Log a warning every DISABLE_WARN_PACKET6.
+        if (stats_mgr.getInteger("pkt6-dhcp-disabled") % DISABLE_WARN_PACKET6 == 0) {
+            LOG_WARN(dhcp6_logger, DHCP6_PACKET_DROP_DHCP_DISABLED)
+                .arg(query->getLabel());
+        }
+
+        // Count packets dropped due to (hopefully temporary) service disabled.
+        stats_mgr.addValue("pkt6-dhcp-disabled", static_cast<int64_t>(1));
         return;
     } else {
         if (MultiThreadingMgr::instance().getMode()) {

--- a/src/bin/dhcp6/dhcp6_srv.h
+++ b/src/bin/dhcp6/dhcp6_srv.h
@@ -43,6 +43,8 @@
 namespace isc {
 namespace dhcp {
 
+static const int64_t DISABLE_WARN_PACKET6 = 100;
+
 /// @brief This exception is thrown when DHCP server hits the error which should
 /// result in discarding the message being processed.
 class DHCPv6DiscardMessageError : public Exception {

--- a/src/bin/dhcp6/tests/ctrl_dhcp6_srv_unittest.cc
+++ b/src/bin/dhcp6/tests/ctrl_dhcp6_srv_unittest.cc
@@ -1392,11 +1392,23 @@ TEST_F(CtrlChannelDhcpv6SrvTest, controlChannelStats) {
                     "  \"name\":\"bogus\" }}", response);
     EXPECT_EQ("{ \"arguments\": {  }, \"result\": 0 }", response);
 
+    // Set max sample count to 1 to match test expectation (disabled state
+    // gauges normally have 2 samples).
+    sendUnixCommand("{ \"command\" : \"statistic-sample-count-set-all\", "
+                    "  \"arguments\": { \"max-samples\": 1 }}", response);
+    EXPECT_EQ("{ \"result\": 0, \"text\": \"All statistics count limit are set.\" }", response);
     // Check statistic-get-all
     sendUnixCommand("{ \"command\" : \"statistic-get-all\", "
                     "  \"arguments\": {}}", response);
 
     std::set<std::string> initial_stats = {
+        "disabled-by-db",
+        "disabled-by-ha-local",
+        "disabled-by-ha-remote",
+        "disabled-by-user",
+        "disabled-globally",
+        "pkt6-dhcp-disabled",
+        "pkt6-raw-received",
         "pkt6-received",
         "pkt6-solicit-received",
         "pkt6-advertise-received",

--- a/src/lib/dhcpsrv/network_state.h
+++ b/src/lib/dhcpsrv/network_state.h
@@ -200,6 +200,9 @@ public:
 
 private:
 
+    /// @brief Update monitoring metrics to expose disable states.
+    void updateStats();
+
     /// @brief Pointer to the @c NetworkState implementation.
     boost::shared_ptr<NetworkStateImpl> impl_;
 

--- a/src/lib/stats/stats_mgr.cc
+++ b/src/lib/stats/stats_mgr.cc
@@ -273,6 +273,25 @@ StatsMgr::removeAllInternal() {
     global_->clear();
 }
 
+int64_t
+StatsMgr::getInteger(const std::string& name) const {
+    if (MultiThreadingMgr::instance().getMode()) {
+        lock_guard<mutex> lock(*mutex_);
+        return (getIntegerInternal(name));
+    } else {
+        return (getIntegerInternal(name));
+    }
+}
+
+int64_t
+StatsMgr::getIntegerInternal(const std::string& name) const {
+    ObservationPtr existing = getObservationInternal(name);
+    if (existing) {
+        return existing->getInteger().first;
+    }
+    return static_cast<int64_t>(0);
+}
+
 ConstElementPtr
 StatsMgr::get(const string& name) const {
     MultiThreadingLock lock(*mutex_);

--- a/src/lib/stats/stats_mgr.h
+++ b/src/lib/stats/stats_mgr.h
@@ -249,6 +249,11 @@ public:
     /// @return number of recorded statistics.
     size_t count() const;
 
+    /// @brief Returns the most recent integer value for a monitoring variable.
+    ///
+    /// @return integer value as a 64 bit integer
+    int64_t getInteger(const std::string& name) const;
+
     /// @brief Returns a single statistic as a JSON structure.
     ///
     /// @return JSON structures representing a single statistic
@@ -712,6 +717,15 @@ private:
     ///
     /// @return number of recorded statistics.
     size_t countInternal() const;
+
+    /// @private
+
+    /// @brief Returns the most recent integer value for a monitoring variable.
+    ///
+    /// Should be called in a thread safe context.
+    ///
+    /// @return integer value as a 64 bit integer
+    int64_t getIntegerInternal(const std::string& name) const;
 
     /// @private
 

--- a/src/lib/stats/tests/stats_mgr_unittest.cc
+++ b/src/lib/stats/tests/stats_mgr_unittest.cc
@@ -76,6 +76,7 @@ TEST_F(StatsMgrTest, integerStat) {
         isc::util::clockToText(alpha->getInteger().second) + "\" ] ] }";
 
     EXPECT_EQ(exp, StatsMgr::instance().get("alpha")->str());
+    EXPECT_EQ(alpha->getInteger().first, StatsMgr::instance().getInteger("alpha"));
 }
 
 // Test checks whether it's possible to record and later report


### PR DESCRIPTION
PROBLEM
=======

We're tracking reported issues in our environment where Kea servers are acting like they are being left disabled by unkonwn causes. Discovering the root cause of that problem has been hampered by poor visibility;

* It is normal for servers to go without receiving packets. When the `pkt?-received` counter stops incrementing, we cannot determine reliably if this is due to e.g. DHCP relay agent misconfiguration or a Kea service issue. It frustrates debugging.

* Kea does not increment any counter to indicate it is disabled, providing us with no clear monitoring predicate to detect the situation early.

* It is consequently hours or days before this is noticed, by which time debug logs have rotated.

This results in the situation of there being no outward indication of disabled state.

SOLUTION
========

In this change, we resolve our visibility problems;

* A new `pkt?-raw-received` counter is incremented at the earliest point of execution we know a packet has been received (in `runOne()`).

* A new `pkt?-dhcp-disabled` counter counts packets dropped due to the service being in a disabled state at the time of reception.

* A WARN level log is emitted for packets dropped while disabled. To alleviate spam concerns, a 1-in-100 sample is used.

  * To facilitate this change, the `StatsMgr` now provides a `getInteger()` method.

* `NetworkState` internal boolean constructs are exposed as monitoring metrics. This allows us to observe the normal process of disabling service during e.g. HA reconnects and recovery, and separately detect extended unexpected disabled states prior to sufficient packet level impacts (consider e.g. DHCP anycast servers which may not receive packets to count as disabled for extended periods - we want to know it had been disabled for several days before the anycast route changes, not after).

This "belt and suspenders" approach should close our monitoring gaps and provide attention to faulty services as they present.

DISCUSSION
==========

The `pkt?-raw-received` counters are a glaring admission of guilt, and we should use `pkt?-received` in these places. The exsisting `pkt?-received` counters should be renamed to `pkt?-processed`, as they indicate execution of the respective `processPacket()` function - still a useful monitoring indicator that e.g. the thread handoff succeeded. Probably there should also be a counter for the case where the callback addition failed instead of the present debug log.

**HOWEVER**, existing Kea users may rely on the present behavior and names of metrics. A monitoring predicate using the current `pkt?-received` metrics may trigger automatic remediation processes for Kea servers unintentionally left disabled for too long; these predicate configurations would have to change or else the remediation would be defeated. This may not be an ideal user experience.

Consequently, I've offered the unfortunate solution you see here; `pkt?-raw-received`, but I'm extremely unhappy with it; I'd be happy to modify the situation to whatever ISC prefers to offer their users in this case.