### PR TITLE
Add lpf IPoIB support

### DIFF
--- a/doc/sphinx/arm/dhcp4-srv.rst
+++ b/doc/sphinx/arm/dhcp4-srv.rst
@@ -8500,9 +8500,11 @@ are clearly marked as such.
    headers (including data link layer, IP, and UDP headers) are created
    and parsed by Kea, rather than by the system kernel. Currently, Kea
    can only parse the data-link layer headers with a format adhering to
-   the IEEE 802.3 standard, and assumes this data-link-layer header
+   the IEEE 802.3 (Ethernet) standard, and assumes this data-link-layer header
    format for all interfaces. Thus, Kea does not work on interfaces
-   which use different data-link-layer header formats (e.g. Infiniband).
+   which use different data-link-layer header formats, with the exception of
+   LPF being able to handle InfiniBand framing, thus enabling Kea to serve
+   these kind of interfaces on Linux.
 
 .. _dhcp4-srv-examples:
 

--- a/src/lib/dhcp/dhcp4.h
+++ b/src/lib/dhcp/dhcp4.h
@@ -60,8 +60,8 @@ enum HType {
                          ///  arp-parameters/arp-parameters.xhtml suggest that
                          ///  Ethernet (1) should be used in DOCSIS environment.
     HTYPE_IEEE802 = 6,   ///< IEEE 802.2 Token Ring
-    HTYPE_FDDI = 8       ///< FDDI
-    /// TODO Add infiniband here
+    HTYPE_FDDI = 8,      ///< FDDI
+    HTYPE_INFINIBAND = 32 ///< InfiniBand
 };
 
 /* DHCP Option codes: */

--- a/src/lib/dhcp/hwaddr.h
+++ b/src/lib/dhcp/hwaddr.h
@@ -23,6 +23,9 @@ public:
     /// @brief Size of an ethernet hardware address.
     static const size_t ETHERNET_HWADDR_LEN = 6;
 
+    /// @brief Size of an infiniband hardware address.
+    static const size_t INFINIBAND_HWADDR_LEN = 20;
+
     /// @brief Maximum size of a hardware address.
     static const size_t MAX_HWADDR_LEN = 20;
 

--- a/src/lib/dhcp/iface_mgr.cc
+++ b/src/lib/dhcp/iface_mgr.cc
@@ -60,7 +60,7 @@ IfaceMgr::instancePtr() {
 }
 
 Iface::Iface(const std::string& name, unsigned int ifindex)
-    : name_(name), ifindex_(ifindex), mac_len_(0), hardware_type_(0),
+    : name_(name), ifindex_(ifindex), mac_len_(0), bcast_mac_len_(0), hardware_type_(0),
       flag_loopback_(false), flag_up_(false), flag_running_(false),
       flag_multicast_(false), flag_broadcast_(false), flags_(0),
       inactive4_(false), inactive6_(false) {
@@ -138,6 +138,21 @@ Iface::getPlainMac() const {
     return (tmp.str());
 }
 
+std::string
+Iface::getPlainBcastMac() const {
+    ostringstream tmp;
+    tmp.fill('0');
+    tmp << hex;
+    for (int i = 0; i < bcast_mac_len_; i++) {
+        tmp.width(2);
+        tmp << static_cast<int>(bcast_mac_[i]);
+        if (i < bcast_mac_len_-1) {
+            tmp << ":";
+        }
+    }
+    return (tmp.str());
+}
+
 void Iface::setMac(const uint8_t* mac, size_t len) {
     if (len > MAX_MAC_LEN) {
         isc_throw(OutOfRange, "Interface " << getFullName()
@@ -148,6 +163,19 @@ void Iface::setMac(const uint8_t* mac, size_t len) {
     mac_len_ = len;
     if (len > 0) {
         memcpy(mac_, mac, len);
+    }
+}
+
+void Iface::setBcastMac(const uint8_t* mac, size_t len) {
+    if (len > MAX_MAC_LEN) {
+        isc_throw(OutOfRange, "Interface " << getFullName()
+                  << " was detected to have link address of length "
+                  << len << ", but maximum supported length is "
+                  << MAX_MAC_LEN);
+    }
+    bcast_mac_len_ = len;
+    if (len > 0) {
+        memcpy(bcast_mac_, mac, len);
     }
 }
 
@@ -849,7 +877,8 @@ IfaceMgr::printIfaces(std::ostream& out /*= std::cout*/) {
 
         out << "Detected interface " << iface->getFullName()
             << ", hwtype=" << iface->getHWType()
-            << ", mac=" << iface->getPlainMac();
+            << ", mac=" << iface->getPlainMac()
+            << ", bcast=" << iface->getPlainBcastMac();
         out << ", flags=" << hex << iface->flags_ << dec << "("
             << (iface->flag_loopback_?"LOOPBACK ":"")
             << (iface->flag_up_?"UP ":"")

--- a/src/lib/dhcp/iface_mgr.h
+++ b/src/lib/dhcp/iface_mgr.h
@@ -242,6 +242,28 @@ public:
         return (mac_);
     }
 
+    /// @brief Returns broadcast MAC address a plain text.
+    ///
+    /// @return MAC address as a plain text (string)
+    std::string getPlainBcastMac() const;
+
+    /// @brief Sets broadcast MAC address of the interface.
+    ///
+    /// @param mac pointer to bcast MAC address buffer
+    /// @param macLen length of bcast mac address
+    void setBcastMac(const uint8_t* bcastMac, size_t bcastMacLen);
+
+    /// @brief Returns broadcast MAC length.
+    ///
+    /// @return length of bcast MAC address
+    size_t getBcastMacLen() const { return bcast_mac_len_; }
+
+    /// @brief Returns pointer to broadcast MAC address.
+    ///
+    /// Note: Returned pointer is only valid as long as the interface object
+    /// that returned it.
+    const uint8_t* getBcastMac() const { return bcast_mac_; }
+
     /// @brief Sets flag_*_ fields based on bitmask value returned by OS
     ///
     /// @note Implementation of this method is OS-dependent as bits have
@@ -497,6 +519,12 @@ protected:
 
     /// Length of link-layer address (usually 6).
     size_t mac_len_;
+
+    /// Link-layer braodcast address.
+    uint8_t bcast_mac_[MAX_MAC_LEN];
+
+    /// Length of link-layer broadcast address (usually 6).
+    size_t bcast_mac_len_;
 
     /// Hardware type.
     uint16_t hardware_type_;

--- a/src/lib/dhcp/pkt_filter_lpf.cc
+++ b/src/lib/dhcp/pkt_filter_lpf.cc
@@ -131,6 +131,98 @@ struct sock_filter dhcp_sock_filter [] = {
     BPF_STMT(BPF_RET + BPF_K, 0),
 };
 
+/// The following structure defines a Berkeley Packet Filter program to perform
+/// packet filtering. The program operates on IPoIB pseudo packets. To help with
+/// interpretation of the program, for the types of packets we are interested
+/// in, the header layout is:
+///
+///  20 bytes  Source Interface Address
+///   2 bytes  Packet Type
+///   2 bytes  Reserved/Unused
+///
+///  The rest is identical to aboves Ethernet-Based packets
+///
+/// Each instruction is preceded with the comments giving the instruction
+/// number within a BPF program, in the following format: #123.
+
+struct sock_filter dhcp_sock_filter_ib [] = {
+    // Make sure this is an IP packet: check the half-word (two bytes)
+    // at offset 20 in the packet (the IPoIB pseudo packet type). If it
+    // is, advance to the next instruction. If not, advance 11
+    // instructions (which takes execution to the last instruction in
+    // the sequence: "drop it").
+    // #0
+    BPF_STMT(BPF_LD + BPF_H + BPF_ABS, IPOIB_PACKET_TYPE_OFFSET),
+    // #1
+    BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, ETHERTYPE_IP, 0, 11),
+
+    // Make sure it's a UDP packet. The IP protocol is at offset
+    // 9 in the IP header so, adding the IPoIB packet header size
+    // of 24 bytes gives an absolute byte offset in the packet of 33.
+    // #2
+    BPF_STMT(BPF_LD + BPF_B + BPF_ABS,
+             IPOIB_HEADER_LEN + IP_PROTO_TYPE_OFFSET),
+    // #3
+    BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, IPPROTO_UDP, 0, 9),
+
+    // Make sure this isn't a fragment by checking that the fragment
+    // offset field in the IP header is zero. This field is the
+    // least-significant 13 bits in the bytes at offsets 6 and 7 in
+    // the IP header, so the half-word at offset 30 (6 + size of
+    // IPoIB header) is loaded and an appropriate mask applied.
+    // #4
+    BPF_STMT(BPF_LD + BPF_H + BPF_ABS, IPOIB_HEADER_LEN + IP_FLAGS_OFFSET),
+    // #5
+    BPF_JUMP(BPF_JMP + BPF_JSET + BPF_K, 0x1fff, 7, 0),
+
+    // Check the packet's destination address. The program will only
+    // allow the packets sent to the broadcast address or unicast
+    // to the specific address on the interface. By default, this
+    // address is set to 0 and must be set to the specific value
+    // when the raw socket is created and the program is attached
+    // to it. The caller must assign the address to the
+    // prog.bf_insns[8].k in the network byte order.
+    // #6
+    BPF_STMT(BPF_LD + BPF_W + BPF_ABS,
+             IPOIB_HEADER_LEN + IP_DEST_ADDR_OFFSET),
+    // If this is a broadcast address, skip the next check.
+    // #7
+    BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 0xffffffff, 1, 0),
+    // If this is not broadcast address, compare it with the unicast
+    // address specified for the interface.
+    // #8
+    BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 0x00000000, 0, 4),
+
+    // Get the IP header length. This is achieved by the following
+    // (special) instruction that, given the offset of the start
+    // of the IP header (offset 24) loads the IP header length.
+    // #9
+    BPF_STMT(BPF_LDX + BPF_B + BPF_MSH, IPOIB_HEADER_LEN),
+
+    // Make sure it's to the right port. The following instruction
+    // adds the previously extracted IP header length to the given
+    // offset to locate the correct byte. The given offset of 26
+    // comprises the length of the IPoIB header (24) plus the offset
+    // of the UDP destination port (2) within the UDP header.
+    // #10
+    BPF_STMT(BPF_LD + BPF_H + BPF_IND, IPOIB_HEADER_LEN + UDP_DEST_PORT),
+    // The following instruction tests against the default DHCP server port,
+    // but the action port is actually set in PktFilterBPF::openSocket().
+    // N.B. The code in that method assumes that this instruction is at
+    // offset 11 in the program. If this is changed, openSocket() must be
+    // updated.
+    // #11
+    BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, DHCP4_SERVER_PORT, 0, 1),
+
+    // If we passed all the tests, ask for the whole packet.
+    // #12
+    BPF_STMT(BPF_RET + BPF_K, (u_int)-1),
+
+    // Otherwise, drop it.
+    // #13
+    BPF_STMT(BPF_RET + BPF_K, 0),
+};
+
 }
 
 using namespace isc::util;
@@ -248,16 +340,29 @@ PktFilterLPF::openSocket(Iface& iface,
     struct sock_fprog filter_program;
     memset(&filter_program, 0, sizeof(filter_program));
 
-    filter_program.filter = dhcp_sock_filter;
-    filter_program.len = sizeof(dhcp_sock_filter) / sizeof(struct sock_filter);
+    if (iface.getHWType() == HTYPE_INFINIBAND) {
+        filter_program.filter = dhcp_sock_filter_ib;
+        filter_program.len = sizeof(dhcp_sock_filter_ib) / sizeof(struct sock_filter);
 
-    // Configure the filter program to receive unicast packets sent to the
-    // specified address. The program will also allow packets sent to the
-    // 255.255.255.255 broadcast address.
-    dhcp_sock_filter[8].k = addr.toUint32();
+        // Configure the filter program to receive unicast packets sent to the
+        // specified address. The program will also allow packets sent to the
+        // 255.255.255.255 broadcast address.
+        dhcp_sock_filter_ib[8].k = addr.toUint32();
 
-    // Override the default port value.
-    dhcp_sock_filter[11].k = port;
+        // Override the default port value.
+        dhcp_sock_filter_ib[11].k = port;
+    } else {
+        filter_program.filter = dhcp_sock_filter;
+        filter_program.len = sizeof(dhcp_sock_filter) / sizeof(struct sock_filter);
+
+        // Configure the filter program to receive unicast packets sent to the
+        // specified address. The program will also allow packets sent to the
+        // 255.255.255.255 broadcast address.
+        dhcp_sock_filter[8].k = addr.toUint32();
+
+        // Override the default port value.
+        dhcp_sock_filter[11].k = port;
+    }
 
     // Apply the filter.
     if (setsockopt(sock, SOL_SOCKET, SO_ATTACH_FILTER, &filter_program,
@@ -356,7 +461,21 @@ PktFilterLPF::receive(Iface& iface, const SocketInfo& socket_info) {
     Pkt4Ptr dummy_pkt = Pkt4Ptr(new Pkt4(DHCPDISCOVER, 0));
 
     // Decode ethernet, ip and udp headers.
-    decodeEthernetHeader(buf, dummy_pkt);
+    if (iface.getHWType() == HTYPE_INFINIBAND) {
+        decodeIPoIBHeader(buf, dummy_pkt);
+
+        // The IPoIB header does not contain the local address.
+        // Set it from the interface instead.
+        if (iface.getMacLen() != HWAddr::INFINIBAND_HWADDR_LEN) {
+            isc_throw(SocketReadError,
+                      "Invalid local hardware address size for IPoIB interface.");
+        }
+        HWAddrPtr hwaddr(new HWAddr(iface.getMac(), iface.getMacLen(),
+                                    iface.getHWType()));
+        dummy_pkt->setLocalHWAddr(hwaddr);
+    } else {
+        decodeEthernetHeader(buf, dummy_pkt);
+    }
     decodeIpUdpHeader(buf, dummy_pkt);
 
     auto v4_len = buf.getLength() - buf.getPosition();
@@ -420,11 +539,14 @@ PktFilterLPF::send(const Iface& iface, uint16_t sockfd, const Pkt4Ptr& pkt) {
         pkt->setLocalHWAddr(hwaddr);
     }
 
-
-    // Ethernet frame header.
-    // Note that we don't validate whether HW addresses in 'pkt'
-    // are valid because they are checked by the function called.
-    writeEthernetHeader(pkt, buf);
+    if (iface.getHWType() == HTYPE_INFINIBAND) {
+        writeIPoIBHeader(iface, pkt, buf);
+    } else {
+        // Ethernet frame header.
+        // Note that we don't validate whether HW addresses in 'pkt'
+        // are valid because they are checked by the function called.
+        writeEthernetHeader(pkt, buf);
+    }
 
     // IP and UDP header
     writeIpUdpHeader(pkt, buf);

--- a/src/lib/dhcp/protocol_util.h
+++ b/src/lib/dhcp/protocol_util.h
@@ -8,6 +8,7 @@
 #define PROTOCOL_UTIL_H
 
 #include <dhcp/pkt4.h>
+#include <dhcp/iface_mgr.h>
 #include <util/buffer.h>
 
 #include <stdint.h>
@@ -38,6 +39,12 @@ static const size_t ETHERNET_PACKET_TYPE_OFFSET = 12;
 /// inclusion of additional headers, which have different names
 /// and locations on different OSes.
 static const uint16_t ETHERNET_TYPE_IP = 0x0800;
+
+/// Size of the IPoIB pseude frame header.
+static const size_t IPOIB_HEADER_LEN = 24;
+/// Offset of the 2-byte word in the IPoIB pseudo packet which
+/// holds the type of the protocol it encapsulates.
+static const size_t IPOIB_PACKET_TYPE_OFFSET = 20;
 
 /// Minimal IPv4 header length.
 static const size_t MIN_IP_HEADER_LEN = 20;
@@ -75,6 +82,25 @@ static const size_t UDP_DEST_PORT = 2;
 /// @throw BadValue if pkt object is NULL.
 void decodeEthernetHeader(util::InputBuffer& buf, Pkt4Ptr& pkt);
 
+/// @brief Decode the IPoIB pseudo header.
+///
+/// This function reads IPoIB pesudo frame header from the provided
+/// buffer at the current read position. The source HW address
+/// is read from the header and assigned as client address in
+/// the pkt object. The buffer read pointer is set to the end
+/// of the IPoIB frame header if read was successful.
+///
+/// @warning This function does not check that the provided 'pkt'
+/// pointer is valid. Caller must make sure that pointer is
+/// allocated.
+///
+/// @param buf input buffer holding header to be parsed.
+/// @param [out] pkt packet object receiving HW source address read from header.
+///
+/// @throw InvalidPacketHeader if packet header is truncated
+/// @throw BadValue if pkt object is NULL.
+void decodeIPoIBHeader(util::InputBuffer& buf, Pkt4Ptr& pkt);
+
 /// @brief Decode IP and UDP header.
 ///
 /// This function reads IP and UDP headers from the provided buffer
@@ -104,6 +130,17 @@ void decodeIpUdpHeader(util::InputBuffer& buf, Pkt4Ptr& pkt);
 /// @param [out] out_buf buffer where a header is written.
 void writeEthernetHeader(const Pkt4Ptr& pkt,
                          util::OutputBuffer& out_buf);
+
+/// @brief Writes IPoIB pseudo frame header into a buffer.
+///
+/// @warning This function does not check that the provided 'pkt'
+/// pointer is valid. Caller must make sure that pointer is
+/// allocated.
+///
+/// @param pkt packet object holding source and destination HW address.
+/// @param [out] out_buf buffer where a header is written.
+void writeIPoIBHeader(const Iface& iface, const Pkt4Ptr& pkt,
+                      util::OutputBuffer& out_buf);
 
 /// @brief Writes both IP and UDP header into output buffer
 ///


### PR DESCRIPTION
I'd like to replace good old dhcpd with something more modern, but we have an InfiniBand network, and thus need IPoIB support for DHCP4.

This is my current work in progress for adding support to the linux lpf side of things.
It's not quite complete, since I'd like to gather some feedback on the interest and way of implementation first, so here is what I got so far.

I couldn't find any documentation on the IPoIB raw header format, but by looking at it, it seems to be just the 20 byte long hwaddr followed by the same 2 byte ethernet protocol type, and two bytes which are always zero.
Based on that, I ended up with this patch.

There is still one issue, which is that in case of a broadcast, InfiniBand does not neccesarily have a generic broadcast address. Instead it has to be queried from the interface, which will need to be added to the generic interface code still.