### PR TITLE
[WORK AROUND?] cfg_option: set default visibility on getAll()

### DIFF
--- a/src/lib/dhcpsrv/cfg_option.h
+++ b/src/lib/dhcpsrv/cfg_option.h
@@ -561,6 +561,7 @@ public:
     ///
     /// @return Pointer to the container holding returned options. This
     /// container is empty if no options have been found.
+    __attribute__ ((visibility ("default")))
     OptionContainerPtr getAll(const std::string& option_space) const;
 
     /// @brief Returns vendor options for the specified vendor id.
@@ -569,6 +570,7 @@ public:
     ///
     /// @return Pointer to the container holding returned options. This
     /// container is empty if no options have been found.
+    __attribute__ ((visibility ("default")))
     OptionContainerPtr getAll(const uint32_t vendor_id) const;
 
     /// @brief Returns all non-vendor or vendor options for the specified


### PR DESCRIPTION
* this probably isn't correct fix, I'm not familiar with kea and don't use it, it was just one of many build failures shown in CI build with gcc-14.

* for some reason with gcc-14 these end hidden, causing dhcp4 link to fail
```
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:00000000000003b2 l     F .text.unlikely   0000000000000045 _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE.cold
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000002990 g     F .text    0000000000000012 _ZNK3isc4dhcp9CfgOption6getAllEj
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000002a20 g     F .text    00000000000000bc _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000002df0 g     F .text    0000000000000046 _ZNK3isc4dhcp9CfgOption14getAllCombinedERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:00000000000029c4 R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllEj-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000002b4a R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000002cc5 R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000002e12 R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllEj-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000002e2a R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000002e6f R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000002f33 R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:000000000000322e R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:00000000000036bc R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:000000000000474b R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllEj-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000006dc8 R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE-0x0000000000000004
gcc13/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:00000000000070ba R_X86_64_PLT32    _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE-0x0000000000000004
```
```
gcc14/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:00000000000027a0 g     F .text    0000000000000012 .hidden _ZNK3isc4dhcp9CfgOption6getAllERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
gcc14/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:0000000000005230 g     F .text    0000000000000047 .hidden _ZNK3isc4dhcp9CfgOption14getAllCombinedERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
gcc14/build/src/lib/dhcpsrv/libkea_dhcpsrv_la-cfg_option.o.dump:00000000000052f0 g     F .text    0000000000000012 .hidden _ZNK3isc4dhcp9CfgOption6getAllEj
```

```
libtool: link: x86_64-oe-linux-g++ -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse --sysroot=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot -Wall -Wextra -Wnon-virtual-dtor -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -Wno-missing-field-initializers -fPIC -O2 -pipe -g -feliminate-unused-debug-types -fcanon-prefix-map -fmacro-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/kea-2.5.8=/usr/src/debug/kea/2.5.8 -fdebug-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/kea-2.5.8=/usr/src/debug/kea/2.5.8 -fmacro-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build=/usr/src/debug/kea/2.5.8 -fdebug-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build=/usr/src/debug/kea/2.5.8 -fdebug-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot= -fmacro-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot= -fdebug-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot-native= -fvisibility-inlines-hidden -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -fcanon-prefix-map -fmacro-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/kea-2.5.8=/usr/src/debug/kea/2.5.8 -fdebug-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/kea-2.5.8=/usr/src/debug/kea/2.5.8 -fmacro-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build=/usr/src/debug/kea/2.5.8 -fdebug-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build=/usr/src/debug/kea/2.5.8 -fdebug-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot= -fmacro-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot= -fdebug-prefix-map=/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot-native= -o .libs/kea-dhcp4 main.o  ./.libs/libdhcp4.a ../../../src/lib/dhcpsrv/.libs/libkea-dhcpsrv.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/process/.libs/libkea-process.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/eval/.libs/libkea-eval.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/dhcp_ddns/.libs/libkea-dhcp_ddns.so ../../../src/lib/process/.libs/libkea-process.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/config/.libs/libkea-cfgclient.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/database/.libs/libkea-database.so ../../../src/lib/eval/.libs/libkea-eval.so ../../../src/lib/dhcp_ddns/.libs/libkea-dhcp_ddns.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/stats/.libs/libkea-stats.so ../../../src/lib/stats/.libs/libkea-stats.so ../../../src/lib/config/.libs/libkea-cfgclient.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/http/.libs/libkea-http.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/dhcp/.libs/libkea-dhcp++.so ../../../src/lib/http/.libs/libkea-http.so ../../../src/lib/dhcp/.libs/libkea-dhcp++.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/hooks/.libs/libkea-hooks.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/dns/.libs/libkea-dns++.so ../../../src/lib/hooks/.libs/libkea-hooks.so ../../../src/lib/database/.libs/libkea-database.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/cc/.libs/libkea-cc.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/log/.libs/libkea-log.so ../../../src/lib/cc/.libs/libkea-cc.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/asiolink/.libs/libkea-asiolink.so ../../../src/lib/asiolink/.libs/libkea-asiolink.so ../../../src/lib/dns/.libs/libkea-dns++.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/cryptolink/.libs/libkea-cryptolink.so ../../../src/lib/cryptolink/.libs/libkea-cryptolink.so ../../../src/lib/log/.libs/libkea-log.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/util/.libs/libkea-util.so ../../../src/lib/util/.libs/libkea-util.so /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/build/src/lib/exceptions/.libs/libkea-exceptions.so ../../../src/lib/exceptions/.libs/libkea-exceptions.so -lpthread -L/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot/usr/lib -llog4cplus -lssl -lcrypto -lboost_system -pthread
/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/14.0.1/ld: ./.libs/libdhcp4.a(dhcp4_srv.o): in function `isc::dhcp::Dhcpv4Srv::appendRequestedVendorOptions(isc::dhcp::Dhcpv4Exchange&)':
/usr/src/debug/kea/2.5.8/src/bin/dhcp4/dhcp4_srv.cc:2356:(.text+0xaac2): undefined reference to `isc::dhcp::CfgOption::getAll(unsigned int) const'
/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/14.0.1/ld: ./.libs/libdhcp4.a(dhcp4_srv.o): in function `isc::dhcp::OptionDescriptor isc::dhcp::CfgOption::get<unsigned int>(unsigned int const&, unsigned short) const':
/usr/src/debug/kea/2.5.8/src/lib/dhcpsrv/cfg_option.h:609:(.text+0xb288): undefined reference to `isc::dhcp::CfgOption::getAll(unsigned int) const'
/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/14.0.1/ld: ./.libs/libdhcp4.a(dhcp4_srv.o): in function `isc::dhcp::Dhcpv4Srv::appendRequestedOptions(isc::dhcp::Dhcpv4Exchange&)':
/usr/src/debug/kea/2.5.8/src/bin/dhcp4/dhcp4_srv.cc:2128:(.text+0xc556): undefined reference to `isc::dhcp::CfgOption::getAll(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const'
/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/14.0.1/ld: ./.libs/libdhcp4.a(dhcp4_srv.o): in function `std::vector<isc::dhcp::OptionDescriptor, std::allocator<isc::dhcp::OptionDescriptor> > isc::dhcp::CfgOption::getList<char [6]>(char const (&) [6], unsigned short) const':
/usr/src/debug/kea/2.5.8/src/lib/dhcpsrv/cfg_option.h:641:(.text._ZNK3isc4dhcp9CfgOption7getListIA6_cEESt6vectorINS0_16OptionDescriptorESaIS5_EERKT_t[_ZNK3isc4dhcp9CfgOption7getListIA6_cEESt6vectorINS0_16OptionDescriptorESaIS5_EERKT_t]+0x86): undefined reference to `isc::dhcp::CfgOption::getAll(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const'
/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/kea/2.5.8/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/14.0.1/ld: ./.libs/libdhcp4.a(dhcp4_srv.o): in function `isc::dhcp::OptionDescriptor isc::dhcp::CfgOption::get<char [6]>(char const (&) [6], unsigned short) const':
/usr/src/debug/kea/2.5.8/src/lib/dhcpsrv/cfg_option.h:609:(.text._ZNK3isc4dhcp9CfgOption3getIA6_cEENS0_16OptionDescriptorERKT_t[_ZNK3isc4dhcp9CfgOption3getIA6_cEENS0_16OptionDescriptorERKT_t]+0x77): undefined reference to `isc::dhcp::CfgOption::getAll(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const'
collect2: error: ld returned 1 exit status
make[5]: *** [Makefile:651: kea-dhcp4] Error 1
```