### PR TITLE
do filename munging with variable expansions

### DIFF
--- a/src/bin/keactrl/keactrl.in
+++ b/src/bin/keactrl/keactrl.in
@@ -118,7 +118,8 @@ get_pid_from_file() {
 
     # Extract the name portion (from last slash to last dot) of the config file name.
     local conf_name
-    conf_name=$(basename -- "${kea_config_file}" | rev | cut -f2- -d'.' | rev)
+    conf_name=${kea_config_file##*/}
+    conf_name=${conf_name%.*}
 
     # Default the directory to --localstatedir / run
     local pid_file_dir


### PR DESCRIPTION
Embedded systems often have very limited CLIs, perhaps without `awk` or `rev` being present.  And there's no reason to invoke 4 external processes when all of this can be done within the shell using POSIX capabilities (which even BusyBox shell has).

fixes: https://gitlab.isc.org/isc-projects/kea/-/issues/3533
