### PR TITLE
Update asiolink for boost 1.87

### DIFF
--- a/src/lib/asiolink/io_address.cc
+++ b/src/lib/asiolink/io_address.cc
@@ -37,7 +37,7 @@ IOAddress::Hash::operator()(const IOAddress &io_address) const {
 // because we'd like to throw our own exception on failure.
 IOAddress::IOAddress(const std::string& address_str) {
     boost::system::error_code err;
-    asio_address_ = ip::address::from_string(address_str, err);
+    asio_address_ = ip::make_address(address_str, err);
     if (err) {
         isc_throw(IOError, "Failed to convert string to address '"
                   << address_str << "': " << err.message());
@@ -116,7 +116,7 @@ IOAddress::isV6Multicast() const {
 uint32_t
 IOAddress::toUint32() const {
     if (asio_address_.is_v4()) {
-        return (asio_address_.to_v4().to_ulong());
+        return (asio_address_.to_v4().to_uint());
     } else {
         isc_throw(BadValue, "Can't convert " << toText()
                   << " address to IPv4.");

--- a/src/lib/asiolink/io_service.cc
+++ b/src/lib/asiolink/io_service.cc
@@ -30,7 +30,7 @@ public:
     /// @brief The constructor.
     IOServiceImpl() :
         io_service_(),
-        work_(new boost::asio::io_service::work(io_service_)) {
+        work_(boost::asio::make_work_guard(io_service_)) {
     };
 
     /// @brief The destructor.
@@ -92,7 +92,7 @@ public:
 
     /// @brief Restarts the IOService in preparation for a subsequent @ref run() invocation.
     void restart() {
-        io_service_.reset();
+        io_service_.restart();
     }
 
     /// @brief Removes IO service work object to let it finish running
@@ -115,12 +115,12 @@ public:
     ///
     /// @param callback The callback to be run on the IO service.
     void post(const std::function<void ()>& callback) {
-        io_service_.post(callback);
+        boost::asio::post(io_service_, callback);
     }
 
 private:
     boost::asio::io_service io_service_;
-    boost::shared_ptr<boost::asio::io_service::work> work_;
+    boost::asio::executor_work_guard<boost::asio::io_service::executor_type> work_;
 };
 
 IOService::IOService() : io_impl_(new IOServiceImpl()) {

--- a/src/lib/asiolink/tcp_endpoint.h
+++ b/src/lib/asiolink/tcp_endpoint.h
@@ -42,7 +42,7 @@ public:
     /// \param port The TCP port number of the endpoint.
     TCPEndpoint(const IOAddress& address, const unsigned short port) :
         asio_endpoint_placeholder_(
-            new boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(address.toText()),
+            new boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address(address.toText()),
                               port)),
         asio_endpoint_(*asio_endpoint_placeholder_)
     {}

--- a/src/lib/asiolink/udp_endpoint.h
+++ b/src/lib/asiolink/udp_endpoint.h
@@ -42,7 +42,7 @@ public:
     /// \param port The UDP port number of the endpoint.
     UDPEndpoint(const IOAddress& address, const unsigned short port) :
         asio_endpoint_placeholder_(
-            new boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(address.toText()),
+            new boost::asio::ip::udp::endpoint(boost::asio::ip::make_address(address.toText()),
                               port)),
         asio_endpoint_(*asio_endpoint_placeholder_)
     {}

--- a/src/lib/asiolink/unix_domain_socket.cc
+++ b/src/lib/asiolink/unix_domain_socket.cc
@@ -83,7 +83,7 @@ public:
     /// @param buffer Buffers holding the data to be sent.
     /// @param handler User supplied callback to be invoked when data have
     /// been sent or sending error is signalled.
-    void doSend(const boost::asio::const_buffers_1& buffer,
+    void doSend(const boost::asio::const_buffer& buffer,
                 const UnixDomainSocket::Handler& handler);
 
 
@@ -103,7 +103,7 @@ public:
     /// @param ec Error code returned as a result of sending the data.
     /// @param length Length of the data sent.
     void sendHandler(const UnixDomainSocket::Handler& remote_handler,
-                     const boost::asio::const_buffers_1& buffer,
+                     const boost::asio::const_buffer& buffer,
                      const boost::system::error_code& ec,
                      size_t length);
 
@@ -127,7 +127,7 @@ public:
     /// @param buffer A buffer into which the data should be received.
     /// @param handler User supplied callback invoked when data have been
     /// received on an error is signalled.
-    void doReceive(const boost::asio::mutable_buffers_1& buffer,
+    void doReceive(const boost::asio::mutable_buffer& buffer,
                    const UnixDomainSocket::Handler& handler);
 
     /// @brief Local handler invoked as a result of asynchronous receive.
@@ -146,7 +146,7 @@ public:
     /// @param ec Error code returned as a result of asynchronous receive.
     /// @param length Size of the received data.
     void receiveHandler(const UnixDomainSocket::Handler& remote_handler,
-                        const boost::asio::mutable_buffers_1& buffer,
+                        const boost::asio::mutable_buffer& buffer,
                         const boost::system::error_code& ec,
                         size_t length);
 
@@ -197,7 +197,7 @@ UnixDomainSocketImpl::asyncSend(const void* data, const size_t length,
 }
 
 void
-UnixDomainSocketImpl::doSend(const boost::asio::const_buffers_1& buffer,
+UnixDomainSocketImpl::doSend(const boost::asio::const_buffer& buffer,
                              const UnixDomainSocket::Handler& handler) {
     auto local_handler = std::bind(&UnixDomainSocketImpl::sendHandler,
                                    shared_from_this(),
@@ -207,7 +207,7 @@ UnixDomainSocketImpl::doSend(const boost::asio::const_buffers_1& buffer,
 
 void
 UnixDomainSocketImpl::sendHandler(const UnixDomainSocket::Handler& remote_handler,
-                                  const boost::asio::const_buffers_1& buffer,
+                                  const boost::asio::const_buffer& buffer,
                                   const boost::system::error_code& ec,
                                   size_t length) {
     // The asynchronous send may return EWOULDBLOCK or EAGAIN on some
@@ -230,7 +230,7 @@ UnixDomainSocketImpl::asyncReceive(void* data, const size_t length,
 }
 
 void
-UnixDomainSocketImpl::doReceive(const boost::asio::mutable_buffers_1& buffer,
+UnixDomainSocketImpl::doReceive(const boost::asio::mutable_buffer& buffer,
                                 const UnixDomainSocket::Handler& handler) {
     auto local_handler = std::bind(&UnixDomainSocketImpl::receiveHandler,
                                    shared_from_this(),
@@ -240,7 +240,7 @@ UnixDomainSocketImpl::doReceive(const boost::asio::mutable_buffers_1& buffer,
 
 void
 UnixDomainSocketImpl::receiveHandler(const UnixDomainSocket::Handler& remote_handler,
-                                     const boost::asio::mutable_buffers_1& buffer,
+                                     const boost::asio::mutable_buffer& buffer,
                                      const boost::system::error_code& ec,
                                      size_t length) {
     // The asynchronous receive may return EWOULDBLOCK or EAGAIN on some

--- a/src/lib/dhcp/iface_mgr.cc
+++ b/src/lib/dhcp/iface_mgr.cc
@@ -1034,7 +1034,7 @@ IfaceMgr::getLocalAddress(const IOAddress& remote_addr, const uint16_t port) {
     }
 
     // Create socket that will be used to connect to remote endpoint.
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
     boost::asio::ip::udp::socket sock(io_service);
 
     boost::system::error_code err_code;


### PR DESCRIPTION
i'm going through boost 1.87 update in chimera linux and kea was one of the things failing to build due to removal of deprecated api from asio, so here are fixes