### PR TITLE
Fix argument order in debug logging for FlexOptionImpl

### DIFF
--- a/src/hooks/dhcp/flex_option/flex_option.cc
+++ b/src/hooks/dhcp/flex_option/flex_option.cc
@@ -490,8 +490,8 @@ void
 FlexOptionImpl::logClass(const ClientClass& client_class, uint16_t code) {
     LOG_DEBUG(flex_option_logger, DBGLVL_TRACE_BASIC,
               FLEX_OPTION_PROCESS_CLIENT_CLASS)
-        .arg(client_class)
-        .arg(code);
+        .arg(code)
+        .arg(client_class);
     return;
 }
 
@@ -550,9 +550,9 @@ FlexOptionImpl::logSubClass(const ClientClass& client_class, uint16_t code,
                             uint16_t container_code) {
     LOG_DEBUG(flex_option_logger, DBGLVL_TRACE_BASIC,
               FLEX_OPTION_PROCESS_SUB_CLIENT_CLASS)
-        .arg(client_class)
         .arg(code)
-        .arg(container_code);
+        .arg(container_code)
+        .arg(client_class);
     return;
 }
 


### PR DESCRIPTION
issue:https://gitlab.isc.org/isc-projects/kea/-/issues/3768
The current log message is incorrectly formatted as:
**FLEX_OPTION_PROCESS_CLIENT_CLASS Skip processing of the option code CLASSNAME for class '125'**
This PR corrects the order of arguments, so the log message will now appear as:
**FLEX_OPTION_PROCESS_CLIENT_CLASS Skip processing of the option code 125 for class 'CLASSNAME**'
A similar issue was found and fixed in the FLEX_OPTION_PROCESS_SUB_CLIENT_CLASS message as well.
**Changes**
Corrected the argument order in FLEX_OPTION_PROCESS_CLIENT_CLASS debug messages.
Corrected the argument order in FLEX_OPTION_PROCESS_SUB_CLIENT_CLASS debug messages.

