### PR TITLE
fix(dhcp4): log DHCP4_REQUEST at lower debug level for consistency

### DIFF
--- a/src/bin/dhcp4/dhcp4_srv.cc
+++ b/src/bin/dhcp4/dhcp4_srv.cc
@@ -2909,7 +2909,7 @@ Dhcpv4Srv::assignLease(Dhcpv4Exchange& ex) {
             .arg(query->getLabel())
             .arg(hint != IOAddress::IPV4_ZERO_ADDRESS() ? hint.toText() : "(no hint)");
     } else {
-        LOG_DEBUG(lease4_logger, DBG_DHCP4_DETAIL, DHCP4_REQUEST)
+        LOG_DEBUG(lease4_logger, DBGLVL_COMMAND, DHCP4_REQUEST)
             .arg(query->getLabel())
             .arg(hint != IOAddress::IPV4_ZERO_ADDRESS() ? hint.toText() : "(no hint)");
     }


### PR DESCRIPTION
Issue:https://gitlab.isc.org/isc-projects/kea/-/issues/3761

This change lowers the debug severity of the DHCP4_REQUEST log message from `DBG_DHCP4_DETAIL` to `DBGLVL_COMMAND`.
- Keeps the message at the debug level, but makes it visible with the typical debug level of 10.
- Aligns with logging conventions already used in the Kea DHCPv4 server, such as `DHCP4_PACKET_RECEIVED`.
- Improves consistency and visibility when debugging DHCP request flows.