### PR TITLE
fix #4149: No description of the data type for option №121 in docs

### DIFF
--- a/doc/sphinx/arm/dhcp4-srv.rst
+++ b/doc/sphinx/arm/dhcp4-srv.rst
@@ -2261,6 +2261,13 @@ what values are accepted for them.
    |                 | 2147483647.                                           |
    +-----------------+-------------------------------------------------------+
 
+.. note::
+
+  Option ``classless-static-route`` has its own data type "internal" and accepts a string with the following mask 
+  as its value: subnet1/netmask1 - router1, subnetN/netmaskN - routerN.
+
+  For example: 10.229.0.128/25 - 10.229.0.1, 10.198.122.47/32 - 10.198.122.1
+
 Kea also supports the Relay Agent Information (RAI, defined in
 `RFC 3046 <https://tools.ietf.org/html/rfc3046>`_) option, sometimes referred to as the relay option, agent
 option, or simply option 82. The option itself is just a container and does not convey any information


### PR DESCRIPTION
Good afternoon!

Close my issue [#4149 in Gitlab.](https://gitlab.isc.org/isc-projects/kea/-/issues/4149)

Example result:
<img width="1305" height="685" alt="image" src="https://github.com/user-attachments/assets/51d91b07-f31c-4f57-a958-6721ca2ea034" />

